### PR TITLE
GCW 1798 close on click for admin app

### DIFF
--- a/app/components/receive-menu.js
+++ b/app/components/receive-menu.js
@@ -92,7 +92,6 @@ export default Ember.Component.extend({
       if(optionsLink.length) {
         Ember.$('.receive-options').not('.hidden').toggleClass('hidden');
         Ember.$('.options-link-open.hidden').toggleClass('hidden');
-        //this.toggleItemClass();
         return false;
       } else if(itemOptionsLink) {
         this.toggleItemClass();

--- a/app/components/receive-menu.js
+++ b/app/components/receive-menu.js
@@ -77,9 +77,29 @@ export default Ember.Component.extend({
 
   confirmReceivingEvent: null,
 
+  toggleItemClass() {
+    var item = this.get("package");
+    Ember.$('.receive-options.' + item.id).toggleClass("hidden");
+    Ember.$('.options-link-open.' + item.id).toggleClass("hidden");
+  },
+
   actions: {
     toggle(hidden) {
       this.set("hidden", hidden);
+      var item = this.get("package");
+      var itemOptionsLink = Ember.$('.options-link-open.' + item.id)[0];
+      var optionsLink = Ember.$('.options-link-open.hidden');
+      if(optionsLink.length) {
+        Ember.$('.receive-options').not('.hidden').toggleClass('hidden');
+        Ember.$('.options-link-open.hidden').toggleClass('hidden');
+        //this.toggleItemClass();
+        return false;
+      } else if(itemOptionsLink) {
+        this.toggleItemClass();
+        return false;
+      } else {
+        return true;
+      }
     },
 
     checkReceiving(event) {

--- a/app/components/toggle-receive-menu-list.js
+++ b/app/components/toggle-receive-menu-list.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  click() {
+    var itemOptionsLink = Ember.$('.options-link-open.hidden');
+    if(itemOptionsLink.length) {
+      Ember.$('.receive-options').not('.hidden').toggleClass('hidden');
+      Ember.$('.options-link-open.hidden').toggleClass('hidden');
+      return false;
+    } else {
+      return true;
+    }
+  }
+});
+

--- a/app/templates/components/receive-item.hbs
+++ b/app/templates/components/receive-item.hbs
@@ -6,40 +6,43 @@
   <div>
     <div class="package-name package-{{pState}} {{if package.hasAllPackagesDispatched 'dispatched'}} {{if package.hasAllPackagesDesignated 'designated'}} {{if (js-and (is-not package.quantity) package.designatedOrdersPackages.length) 'designated'}}">
       <div class="small-4 columns">
-        {{#if (is-equal pState "missing")}}
-          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-          {{capitalize-string pState}}
-        {{else if package.hasAllPackagesDesignated}}
-          {{#if package.hasOneDesignatedPackage}}
-            <i class="fa fa-shopping-basket"></i> {{package.designation.code}}
-          {{else}}
-            <i class="fa fa-shopping-basket"></i> {{t "item.multiple_designation"}}
-          {{/if}}
-        {{else if package.hasAllPackagesDispatched}}
-          {{#if package.hasOneDispatchedPackage}}
-            <i class="fa fa-ship"></i> {{package.hasOneDispatchedPackage.designation.code}}
-          {{else}}
-            <i class="fa fa-ship"></i> {{t "item.all_dispatched"}}
-          {{/if}}
-        {{else if (is-not package.quantity)}}
-          {{#if package.hasOneDesignatedPackage}}
-            <i class="fa fa-shopping-basket"></i> {{package.designation.code}}
-          {{else if package.designatedOrdersPackages.length}}
-            <i class="fa fa-shopping-basket"></i> {{t "item.multiple_designation"}}
-          {{else if package.hasOneDispatchedPackage}}
-            <i class="fa fa-ship"></i> {{package.hasOneDispatchedPackage.designation.code}}
-          {{else if package.dispatchedOrdersPackages.length}}
-            <i class="fa fa-ship"></i> {{t "item.all_dispatched"}}
-          {{/if}}
-        {{else}}
-          {{#if (is-equal pState "expecting")}}
-            {{t "item.accepted"}}
-          {{else}}
+        {{#toggle-receive-menu-list}}
+          {{#if (is-equal pState "missing")}}
+            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
             {{capitalize-string pState}}
+          {{else if package.hasAllPackagesDesignated}}
+            {{#if package.hasOneDesignatedPackage}}
+              <i class="fa fa-shopping-basket"></i> {{package.designation.code}}
+            {{else}}
+              <i class="fa fa-shopping-basket"></i> {{t "item.multiple_designation"}}
+            {{/if}}
+          {{else if package.hasAllPackagesDispatched}}
+            {{#if package.hasOneDispatchedPackage}}
+              <i class="fa fa-ship"></i> {{package.hasOneDispatchedPackage.designation.code}}
+            {{else}}
+              <i class="fa fa-ship"></i> {{t "item.all_dispatched"}}
+            {{/if}}
+          {{else if (is-not package.quantity)}}
+            {{#if package.hasOneDesignatedPackage}}
+              <i class="fa fa-shopping-basket"></i> {{package.designation.code}}
+            {{else if package.designatedOrdersPackages.length}}
+              <i class="fa fa-shopping-basket"></i> {{t "item.multiple_designation"}}
+            {{else if package.hasOneDispatchedPackage}}
+              <i class="fa fa-ship"></i> {{package.hasOneDispatchedPackage.designation.code}}
+            {{else if package.dispatchedOrdersPackages.length}}
+              <i class="fa fa-ship"></i> {{t "item.all_dispatched"}}
+            {{/if}}
+          {{else}}
+            {{#if (is-equal pState "expecting")}}
+              {{t "item.accepted"}}
+            {{else}}
+              {{capitalize-string pState}}
+            {{/if}}
           {{/if}}
-        {{/if}}
+        {{/toggle-receive-menu-list}}
       </div>
       <div class="small-4 columns location-name">
+        {{#toggle-receive-menu-list}}
         {{#unless package.hasAllPackagesDispatched}}
           <i class="fa fa-map-marker"></i>
           {{#if package.hasSingleLocation}}
@@ -50,28 +53,35 @@
             NA
           {{/if}}
         {{/unless}}
+        {{/toggle-receive-menu-list}}
       </div>
       <div class="small-4 columns inventory-number">
-        <i class="fa {{if item.isSet 'fa-tags' 'fa-tag'}}"></i>
-        {{#if package.inventoryNumber}}
-          {{package.inventoryNumber}}
-        {{else}}
-          NA
-        {{/if}}
+        {{#toggle-receive-menu-list}}
+          <i class="fa {{if item.isSet 'fa-tags' 'fa-tag'}}"></i>
+          {{#if package.inventoryNumber}}
+            {{package.inventoryNumber}}
+          {{else}}
+            NA
+          {{/if}}
+        {{/toggle-receive-menu-list}}
       </div>
     </div>
     <img src="{{package.displayImageUrl}}" />
     <div class="package-description">
-      <div class="ellipsis name one-line-ellipsis" style="display: inline !important;">
-        {{package.receivedQuantity}} x {{package.packageName}}
-      </div>
-      <span style="margin-left: 0.25rem;">{{package.remainingQty}}/{{package.totalDesignatedQty}}/{{package.totalDispatchedQty}}</span>
+      {{#toggle-receive-menu-list}}
+        <div class="ellipsis name one-line-ellipsis" style="display: inline !important;">
+          {{package.receivedQuantity}} x {{package.packageName}}
+        </div>
+        <span style="margin-left: 0.25rem;">{{package.remainingQty}}/{{package.totalDesignatedQty}}/{{package.totalDispatchedQty}}</span>
+      {{/toggle-receive-menu-list}}
       {{receive-menu packageId=package.id}}
-      <div class="ellipsis two-line-ellipsis">
-        {{js-or package.notes item.donorDescription}}
-      </div>
-      <br/>
-      {{package.dimensions}}
+      {{#toggle-receive-menu-list}}
+        <div class="ellipsis two-line-ellipsis">
+          {{js-or package.notes item.donorDescription}}
+        </div>
+        <br/>
+        {{package.dimensions}}
+      {{/toggle-receive-menu-list}}
     </div>
   </div>
   <div class="sep"></div>

--- a/app/templates/components/receive_menu.hbs
+++ b/app/templates/components/receive_menu.hbs
@@ -1,4 +1,4 @@
-<div class="options-link-open {{if hidden '' 'hidden'}}" {{action "toggle" false}}>
+<div class="options-link-open {{if hidden '' 'hidden'}} {{packageId}}" {{action "toggle" false}}>
   <i class="fa fa-angle-left"></i>
 </div>
 
@@ -6,7 +6,7 @@
   Sent to Printer..
 </div>
 
-<div class="receive-options {{if hidden 'hidden' ''}}">
+<div class="receive-options {{if hidden 'hidden' ''}} {{packageId}}">
   {{#if preventEdit}}
     <div class="disabled">
       <i class="fa fa-pencil-square-o"></i>

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
     - ~/android-sdk
   pre:
     - brew update
-    - brew install homebrew/versions/node4-lts
+    - brew install homebrew/core/node4-lts
     - brew install watchman
     - mkdir -p ${ANDROID_HOME}
     - if ! $(grep -q "Revision=23.0.1" ${ANDROID_HOME}/tools/source.properties); then (curl -o ~/android-sdk.zip https://dl.google.com/android/repository/tools_r23.0.1-macosx.zip && unzip -d ${ANDROID_HOME} ~/android-sdk.zip) && (( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui --all --filter platform-tools,build-tools-23.0.1,android-23,extra-android-m2repository,extra-google-m2repository); fi

--- a/tests/acceptance/receive-tab-close-options-test.js
+++ b/tests/acceptance/receive-tab-close-options-test.js
@@ -1,0 +1,77 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import '../factories/orders_package';
+import '../factories/packages_location';
+import { module, test } from 'qunit';
+import '../factories/offer';
+import FactoryGuy from 'ember-data-factory-guy';
+import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
+
+var App, offer1, item1, package1, package2, package3, orders_pkg1, packages_location;
+
+module('Received Tab close options', {
+  beforeEach: function() {
+    App = startApp({}, 2);
+    TestHelper.setup();
+    item1 = FactoryGuy.make("item", {state: "accepted"});
+    offer1 = FactoryGuy.make("offer", { state: "received", items: [item1] });
+    packages_location = FactoryGuy.make("packages_location");
+    orders_pkg1 = FactoryGuy.make("orders_package", { id: 500, state: "designated", quantity: 6});
+    package1 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "expecting", item: item1});
+    package2 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "expecting", item: item1});
+    package3 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "expecting", item: item1});
+
+  },
+  afterEach: function() {
+    Em.run(function() { TestHelper.teardown(); });
+    Ember.run(App, 'destroy');
+  }
+});
+
+test("Clicking on receive item options closes other receive-options if already open", function(assert) {
+  assert.expect(3);
+  visit("/offers/"+offer1.id+"/review_offer/receive");
+  $.mockjax({url: '/api/v1/packages_location*', type: 'GET', status: 200,responseText: {
+      packages_locations: [packages_location.toJSON({includeId: true})]
+    }
+  });
+  $.mockjax({url: '/api/v1/orders_package*', type: 'GET', status: 200,responseText: {
+      orders_packages: [orders_pkg1.toJSON({includeId: true})]
+    }
+  });
+
+  andThen(function(){
+    //clicking on item options of first package
+    Ember.$('.options-link-open.' + package1.id).click();
+    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package1.id), true);
+    //clicking on item optins of second package
+    Ember.$('.options-link-open.' + package2.id).click();
+    //checking if item option is closed for first package
+    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package1.id), false);
+    //checking if item option is open for second package
+    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package2.id), true);
+  });
+});
+
+test("Clicking on other item detail closes item options", function(assert) {
+  assert.expect(2);
+  visit("/offers/"+offer1.id+"/review_offer/receive");
+  $.mockjax({url: '/api/v1/packages_location*', type: 'GET', status: 200,responseText: {
+      packages_locations: [packages_location.toJSON({includeId: true})]
+    }
+  });
+  $.mockjax({url: '/api/v1/orders_package*', type: 'GET', status: 200,responseText: {
+      orders_packages: [orders_pkg1.toJSON({includeId: true})]
+    }
+  });
+
+  andThen(function(){
+    //clicking on item options of first package
+    Ember.$('.options-link-open.' + package1.id).click();
+    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package1.id), true);
+    //clicking on item status of second package
+    Ember.$('.package-expecting:first div div').click();
+    //checking if item option is closed for first package
+    assert.equal(Ember.$('.receive-options.' + package1.id).attr('class').includes('hidden'), true);
+  });
+});

--- a/tests/acceptance/receive-tab-close-options-test.js
+++ b/tests/acceptance/receive-tab-close-options-test.js
@@ -7,19 +7,19 @@ import '../factories/offer';
 import FactoryGuy from 'ember-data-factory-guy';
 import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
 
-var App, offer1, item1, package1, package2, package3, orders_pkg1, packages_location;
+var App, ofr1, item, pkg1, pkg2, pkg3, order_pkg, packages_location;
 
 module('Received Tab close options', {
   beforeEach: function() {
     App = startApp({}, 2);
     TestHelper.setup();
-    item1 = FactoryGuy.make("item", {state: "accepted"});
-    offer1 = FactoryGuy.make("offer", { state: "received", items: [item1] });
+    item = FactoryGuy.make("item", {state: "accepted"});
+    ofr1 = FactoryGuy.make("offer", { state: "received", items: [item] });
     packages_location = FactoryGuy.make("packages_location");
-    orders_pkg1 = FactoryGuy.make("orders_package", { id: 500, state: "designated", quantity: 6});
-    package1 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "expecting", item: item1});
-    package2 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "expecting", item: item1});
-    package3 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "expecting", item: item1});
+    order_pkg = FactoryGuy.make("orders_package", { id: 500, state: "designated", quantity: 6});
+    pkg1 = FactoryGuy.make("package", { offerId: parseInt(ofr1.id), state: "expecting", item: item});
+    pkg2 = FactoryGuy.make("package", { offerId: parseInt(ofr1.id), state: "expecting", item: item});
+    pkg3 = FactoryGuy.make("package", { offerId: parseInt(ofr1.id), state: "expecting", item: item});
 
   },
   afterEach: function() {
@@ -29,49 +29,47 @@ module('Received Tab close options', {
 });
 
 test("Clicking on receive item options closes other receive-options if already open", function(assert) {
-  assert.expect(3);
-  visit("/offers/"+offer1.id+"/review_offer/receive");
+  assert.expect(2);
+  visit("/offers/"+ofr1.id+"/review_offer/receive");
   $.mockjax({url: '/api/v1/packages_location*', type: 'GET', status: 200,responseText: {
       packages_locations: [packages_location.toJSON({includeId: true})]
     }
   });
   $.mockjax({url: '/api/v1/orders_package*', type: 'GET', status: 200,responseText: {
-      orders_packages: [orders_pkg1.toJSON({includeId: true})]
+      orders_packages: [order_pkg.toJSON({includeId: true})]
     }
   });
 
   andThen(function(){
     //clicking on item options of first package
-    Ember.$('.options-link-open.' + package1.id).click();
-    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package1.id), true);
+    Ember.$('.options-link-open.' + pkg1.id).click();
+    assert.equal($('.receive-options').not('.hidden').length, 1);
     //clicking on item optins of second package
-    Ember.$('.options-link-open.' + package2.id).click();
+    Ember.$('.options-link-open.' + pkg2.id).click();
     //checking if item option is closed for first package
-    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package1.id), false);
-    //checking if item option is open for second package
-    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package2.id), true);
+    assert.equal($('.receive-options .hidden').length, 0);
   });
 });
 
 test("Clicking on other item detail closes item options", function(assert) {
   assert.expect(2);
-  visit("/offers/"+offer1.id+"/review_offer/receive");
+  visit("/offers/"+ofr1.id+"/review_offer/receive");
   $.mockjax({url: '/api/v1/packages_location*', type: 'GET', status: 200,responseText: {
       packages_locations: [packages_location.toJSON({includeId: true})]
     }
   });
   $.mockjax({url: '/api/v1/orders_package*', type: 'GET', status: 200,responseText: {
-      orders_packages: [orders_pkg1.toJSON({includeId: true})]
+      orders_packages: [order_pkg.toJSON({includeId: true})]
     }
   });
 
   andThen(function(){
     //clicking on item options of first package
-    Ember.$('.options-link-open.' + package1.id).click();
-    assert.equal(Ember.$('.receive-options').not('.hidden').attr('class').includes(package1.id), true);
+    Ember.$('.options-link-open.' + pkg1.id).click();
+    assert.equal($('.receive-options').not('.hidden').length, 1);
     //clicking on item status of second package
     Ember.$('.package-expecting:first div div').click();
     //checking if item option is closed for first package
-    assert.equal(Ember.$('.receive-options.' + package1.id).attr('class').includes('hidden'), true);
+    assert.equal(Ember.$('.receive-options').not('.hidden').length, 0);
   });
 });


### PR DESCRIPTION
Hi Team,
This PR is for ticket  https://jira.crossroads.org.hk/browse/GCW-1798.

It contains following changes:
- Only keeps one item option at a time
- Item option can be closed by clicking on any  
- Same feature as implemented in Stock App https://jira.crossroads.org.hk/browse/GCW-1775
- Test cases added
- Increases code-coverage by 1.1%

Thanks.