### PR TITLE
GCW-2482- Changing the item type for components isn't working

### DIFF
--- a/app/components/package-select-list.js
+++ b/app/components/package-select-list.js
@@ -1,8 +1,8 @@
 import Ember from "ember";
-import SelectList from './select-list';
+import SelectList from "./select-list";
 
-export default SelectList.extend( {
-  layoutName: 'components/select-list',
+export default SelectList.extend({
+  layoutName: "components/select-list",
   content: null,
   selectedValue: null,
   pkg: null,
@@ -11,43 +11,53 @@ export default SelectList.extend( {
 
   didRender() {
     this._super(...arguments);
-    if (!this.get('didUpdatedOnce') && this.get('pkg') !== null && this.get('pkg.item.packageType') !== null){
-        var packageType = this.get('pkg.item.packageType');
-
-        if (this.isPackageTypeChanged(packageType)) {
-          this.set('pkg.notes', packageType.get('name'));
-        }
-        this.set('pkg.packageType', packageType);
-      Ember.$("textarea#"+this.get('index')).val(this.get('pkg.notes'));
-      this.set('didUpdatedOnce', false);
+    if (
+      !this.get("didUpdatedOnce") &&
+      this.get("pkg") !== null &&
+      this.get("pkg.item.packageType") !== null
+    ) {
+      const packageType =
+        this.get("pkg.packageType") || this.get("pkg.item.packageType");
+      if (this.isPackageTypeChanged(packageType)) {
+        this.set("pkg.notes", packageType.get("name"));
+      }
+      this.set("pkg.packageType", packageType);
+      Ember.$("textarea#" + this.get("index")).val(this.get("pkg.notes"));
+      this.set("didUpdatedOnce", false);
     }
   },
 
   isPackageTypeChanged(packageType) {
-    return this.get('pkg.notes') === packageType.get('name') || this.get('pkg.notes').trim().length === 0 || (this.get('pkg.packageType.name') !== packageType.get('name'));
+    return (
+      this.get("pkg.notes") === packageType.get("name") ||
+      this.get("pkg.notes").trim().length === 0 ||
+      this.get("pkg.packageType.name") !== packageType.get("name")
+    );
   },
 
   didUpdate() {
     this._super(...arguments);
-    this.set('pkg.packageType', this.get('pkg.packageType'));
-    this.set('didUpdatedOnce', true);
+    this.set("pkg.packageType", this.get("pkg.packageType"));
+    this.set("didUpdatedOnce", true);
   },
 
   actions: {
     change() {
-      const changeAction  = this.get('on-change');
-      const selectedIndex = this.$('select').prop('selectedIndex');
-      var content         = this.get('content').toArray();
-      if (this.get("prompt")) { content = [{name:null}].concat(content); }
-      const selectedValue = content[selectedIndex];
-      if(this.index !== null && selectedValue.name !== null ){
-        selectedValue.set('indexOfChild', this.get('index'));
-        var availablePkg = this.get("pkg");
-        var name = selectedValue.get('name');
-        Ember.$("textarea#"+this.get('index')).val(name);
-        selectedValue.set('indexOfChild', availablePkg.id);
+      const changeAction = this.get("on-change");
+      const selectedIndex = this.$("select").prop("selectedIndex");
+      var content = this.get("content").toArray();
+      if (this.get("prompt")) {
+        content = [{ name: null }].concat(content);
       }
-      this.set('selectedValue', selectedValue);
+      const selectedValue = content[selectedIndex];
+      if (this.index !== null && selectedValue.name !== null) {
+        selectedValue.set("indexOfChild", this.get("index"));
+        var availablePkg = this.get("pkg");
+        var name = selectedValue.get("name");
+        Ember.$("textarea#" + this.get("index")).val(name);
+        selectedValue.set("indexOfChild", availablePkg.id);
+      }
+      this.set("selectedValue", selectedValue);
       changeAction(selectedValue);
     }
   }


### PR DESCRIPTION
Hi Team,
This PR fixes issue related to changing of component's `PackageType` and `Notes` on going back and forth in item's accept page. It was because we were applying `notes` and `packageType` of Item's `packageType` instead of `package` itself.  
`const packageType = this.get("pkg.packageType") || this.get("pkg.item.packageType");` .
This change will also fix issue mentioned in ticket GCW-2228 and GCW-2493.
Please review the PR and let me know if any change is required.
Thanks