### PR TITLE
GCW-2559-User-entered parametres are cleared in the "Inventory" tab when receiving an item

### DIFF
--- a/app/templates/receive_package.hbs
+++ b/app/templates/receive_package.hbs
@@ -75,7 +75,7 @@
       </div>
     </div>
 
-    {{inventory-number-input inputId=(concat 'inventory_number' package.id) value=packageForm.inventoryNumber packageId=package.id invalid=invalidInventoryNo name="inventoryNumber" }}
+    {{inventory-number-input inputId=(concat 'inventory_number' package.id) value=inventoryNumber packageId=package.id invalid=invalidInventoryNo name="inventoryNumber" }}
 
     <div class="row inventory-number">
       <div class="small-12 columns">


### PR DESCRIPTION
Hi Team,
This PR has fix for resetting of receive package form on printing Inventory number. It was because all fields of `Package` were grouped inside single computed property (`packageForm`). On calling `print_barcode`, the inventory_number is updated which calls the `packageForm` computed property and it resets all fields. I separated `inventory_number` field from `packageForm`. I did some clean up of `receivePackage` method.
Please review this PR.
Thanks.