### PR TITLE
GCW-2559 print inventory cleans form data

### DIFF
--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -11,6 +11,7 @@ export default Ember.Controller.extend({
   isAndroidDevice: false,
   i18n: Ember.inject.service(),
   reviewOfferController: Ember.inject.controller("review_offer"),
+  displayError: false,
 
   donorConditions: Ember.computed(function() {
     return this.get("store")
@@ -94,27 +95,17 @@ export default Ember.Controller.extend({
   }),
 
   isInvalidInventoryNo: Ember.computed("inventoryNumber", function() {
-    console.log(
-      "isInvalidInventoryNo:",
-      this.verifyInventoryNumber(this.get("inventoryNumber"))
-    );
     return !this.verifyInventoryNumber(this.get("inventoryNumber"));
   }),
 
-  hasErrors: Ember.computed(
-    "isInvalidQuantity",
-    "isInvalidDescription",
-    "isInvalidLocation",
-    "isInvalidInventoryNo",
-    function() {
-      return (
-        this.get("isInvalidQuantity") ||
-        this.get("isInvalidInventoryNo") ||
-        this.get("isInvalidDescription") ||
-        this.get("isInvalidLocation")
-      );
-    }
-  ),
+  isPackageValid: function() {
+    return (
+      this.get("isInvalidQuantity") ||
+      this.get("isInvalidInventoryNo") ||
+      this.get("isInvalidDescription") ||
+      this.get("isInvalidLocation")
+    );
+  },
 
   receivePackageParams() {
     const pkgData = this.get("packageForm");
@@ -170,7 +161,8 @@ export default Ember.Controller.extend({
     },
 
     receivePackage() {
-      if (!this.hasErrors) {
+      if (this.isPackageValid()) {
+        this.set("displayError", true);
         return false;
       }
       const loadingView = getOwner(this)
@@ -209,7 +201,7 @@ export default Ember.Controller.extend({
           () => pkg.rollbackAttributes()
         );
       } else {
-        this.set("hasErrors", true);
+        this.set("displayError", true);
       }
     },
 

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -50,16 +50,11 @@ export default Ember.Controller.extend({
     return this.store.peekRecord("location", this.get("locationId"));
   }),
 
-  locationId: Ember.computed("package", {
-    get: function() {
-      return (
-        this.get("package.location.id") ||
-        this.get("package.packageType.location.id")
-      );
-    },
-    set: function(key, value) {
-      return value;
-    }
+  locationId: Ember.computed("package", function() {
+    return (
+      this.get("package.location.id") ||
+      this.get("package.packageType.location.id")
+    );
   }),
 
   locations: Ember.computed(function() {
@@ -81,40 +76,24 @@ export default Ember.Controller.extend({
     }
   }),
 
-  disableDisplayError() {
-    this.set("displayError", false);
+  enableDisplayError() {
+    this.set("displayError", true);
   },
 
   isInvalidQuantity: Ember.computed("packageForm.quantity", function() {
-    const isValid = this.get("packageForm.quantity") < 1;
-    if (isValid) {
-      this.disableDisplayError();
-    }
-    return isValid;
+    return this.get("packageForm.quantity") < 1;
   }),
 
   isInvalidLocation: Ember.computed("locationId", function() {
-    const isValid = !this.get("locationId");
-    if (isValid) {
-      this.disableDisplayError();
-    }
-    return isValid;
+    return !this.get("locationId");
   }),
 
   isInvalidDescription: Ember.computed("packageForm.notes", function() {
-    const isValid = this.get("package.notes").length === 0;
-    if (isValid) {
-      this.disableDisplayError();
-    }
-    return isValid;
+    return this.get("package.notes").length === 0;
   }),
 
   isInvalidInventoryNo: Ember.computed("inventoryNumber", function() {
-    const isValid = !this.verifyInventoryNumber(this.get("inventoryNumber"));
-    if (isValid) {
-      this.disableDisplayError();
-    }
-    return isValid;
+    return !this.verifyInventoryNumber(this.get("inventoryNumber"));
   }),
 
   isPackageInvalid: Ember.computed(
@@ -187,7 +166,7 @@ export default Ember.Controller.extend({
 
     receivePackage() {
       if (this.get("isPackageInvalid")) {
-        this.set("displayError", true);
+        this.enableDisplayError();
         return false;
       }
       const loadingView = getOwner(this)
@@ -226,7 +205,7 @@ export default Ember.Controller.extend({
           () => pkg.rollbackAttributes()
         );
       } else {
-        this.set("displayError", true);
+        this.enableDisplayError();
       }
     },
 

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -81,31 +81,56 @@ export default Ember.Controller.extend({
     }
   }),
 
+  disableDisplayError() {
+    this.set("displayError", false);
+  },
+
   isInvalidQuantity: Ember.computed("packageForm.quantity", function() {
-    const quantity = this.get("packageForm.quantity");
-    return Number(quantity) < 1;
+    const isValid = this.get("packageForm.quantity") < 1;
+    if (isValid) {
+      this.disableDisplayError();
+    }
+    return isValid;
   }),
 
   isInvalidLocation: Ember.computed("locationId", function() {
-    return this.get("locationId") === undefined;
+    const isValid = !this.get("locationId");
+    if (isValid) {
+      this.disableDisplayError();
+    }
+    return isValid;
   }),
 
   isInvalidDescription: Ember.computed("packageForm.notes", function() {
-    return this.get("package.notes").length === 0;
+    const isValid = this.get("package.notes").length === 0;
+    if (isValid) {
+      this.disableDisplayError();
+    }
+    return isValid;
   }),
 
   isInvalidInventoryNo: Ember.computed("inventoryNumber", function() {
-    return !this.verifyInventoryNumber(this.get("inventoryNumber"));
+    const isValid = !this.verifyInventoryNumber(this.get("inventoryNumber"));
+    if (isValid) {
+      this.disableDisplayError();
+    }
+    return isValid;
   }),
 
-  isPackageValid: function() {
-    return (
-      this.get("isInvalidQuantity") ||
-      this.get("isInvalidInventoryNo") ||
-      this.get("isInvalidDescription") ||
-      this.get("isInvalidLocation")
-    );
-  },
+  isPackageInvalid: Ember.computed(
+    "isInvalidQuantity",
+    "isInvalidInventoryNo",
+    "isInvalidDescription",
+    "isInvalidLocation",
+    function() {
+      return (
+        this.get("isInvalidQuantity") ||
+        this.get("isInvalidInventoryNo") ||
+        this.get("isInvalidDescription") ||
+        this.get("isInvalidLocation")
+      );
+    }
+  ),
 
   receivePackageParams() {
     const pkgData = this.get("packageForm");
@@ -161,7 +186,7 @@ export default Ember.Controller.extend({
     },
 
     receivePackage() {
-      if (this.isPackageValid()) {
+      if (this.get("isPackageInvalid")) {
         this.set("displayError", true);
         return false;
       }

--- a/app/templates/receive_package.hbs
+++ b/app/templates/receive_package.hbs
@@ -2,19 +2,21 @@
 
   <section class="main-section receive_package_modal">
 
-    <div class="row single-row {{if hasErrors 'form-errors' 'no-error'}}">
-      <div class="small-1 columns">
-        <i class="fa fa-exclamation-triangle"></i>
-      </div>
+    <div class="row single-row form-errors">
+      {{#if isInvalidInventoryNo}}
+        <div class="small-1 columns">
+          <i class="fa fa-exclamation-triangle"></i>
+        </div>
+      {{/if}}
       <div class="small-11 columns">
 
-        <div class={{if invalidInventoryNo 'show-error' 'no-error'}}>{{t "receive_package.invalid_inventory"}}</div>
+        <div class={{if isInvalidInventoryNo 'show-error' 'no-error'}}>{{t "receive_package.invalid_inventory"}}</div>
 
-        <div class={{if invalidQuantity 'show-error' 'no-error'}}>{{t "receive_package.invalid_quantity"}}</div>
+        <div class={{if isInvalidQuantity 'show-error' 'no-error'}}>{{t "receive_package.invalid_quantity"}}</div>
 
-        <div class={{if invalidDescription 'show-error' 'no-error'}}>{{t "receive_package.invalid_description"}}</div>
+        <div class={{if isInvalidDescription 'show-error' 'no-error'}}>{{t "receive_package.invalid_description"}}</div>
 
-        <div class={{if invalidLocation 'show-error' 'no-error'}}>{{t "receive_package.invalid_location"}}</div>
+        <div class={{if isInvalidLocation 'show-error' 'no-error'}}>{{t "receive_package.invalid_location"}}</div>
 
         {{#each package.errors.messages as |message|}}
           <div class='show-error'>{{message}}</div>
@@ -32,13 +34,13 @@
       </div>
 
       <div class="row inputs-row">
-        <div class="small-12 columns {{if invalidDescription 'has-error'}}">
+        <div class="small-12 columns {{if isInvalidDescription 'has-error'}}">
           {{auto-resize-textarea data-autoresize=true name="notes" value=packageForm.notes placeholder=(t "placeholder.comments") maxlength="50" required="required" pattern=".*\S.*" id=(concat 'notes' package.id)}}
         </div>
       </div>
 
       <div class="row inputs-row">
-        <div class="small-3 columns {{if invalidQuantity 'has-error'}}">
+        <div class="small-3 columns {{if isInvalidQuantity 'has-error'}}">
           {{numeric-input id=(concat 'qty' package.id) name="qty" value=packageForm.quantity placeholder=(t "placeholder.qty") maxlength="8" pattern="\d{1,8}"}}
           <i class="fa fa-exclamation-triangle"></i>
         </div>
@@ -75,7 +77,7 @@
       </div>
     </div>
 
-    {{inventory-number-input inputId=(concat 'inventory_number' package.id) value=inventoryNumber packageId=package.id invalid=invalidInventoryNo name="inventoryNumber" }}
+    {{inventory-number-input inputId=(concat 'inventory_number' package.id) value=inventoryNumber packageId=package.id invalid=isInvalidInventoryNo name="inventoryNumber" }}
 
     <div class="row inventory-number">
       <div class="small-12 columns">

--- a/app/templates/receive_package.hbs
+++ b/app/templates/receive_package.hbs
@@ -75,7 +75,7 @@
       </div>
     </div>
 
-    {{inventory-number-input inputId=(concat 'inventory_number' package.id) value=packageForm.inventoryNumber packageId=package.id invalid=invalidInventoryNo name="inventoryNumber" }}
+    {{inventory-number-input inputId=(concat 'inventory_number' package.id) value=inventoryNumber packageId=package.id invalid=invalidInventoryNo name="inventoryNumber" }}
 
     <div class="row inventory-number">
       <div class="small-12 columns">

--- a/app/templates/receive_package.hbs
+++ b/app/templates/receive_package.hbs
@@ -2,28 +2,30 @@
 
   <section class="main-section receive_package_modal">
 
-    <div class="row single-row form-errors">
-      {{#if isInvalidInventoryNo}}
-        <div class="small-1 columns">
-          <i class="fa fa-exclamation-triangle"></i>
+    {{#if displayError}}
+      <div class="row single-row form-errors">
+        {{#if isInvalidInventoryNo}}
+          <div class="small-1 columns">
+            <i class="fa fa-exclamation-triangle"></i>
+          </div>
+        {{/if}}
+        <div class="small-11 columns">
+
+          <div class={{if isInvalidInventoryNo 'show-error' 'no-error'}}>{{t "receive_package.invalid_inventory"}}</div>
+
+          <div class={{if isInvalidQuantity 'show-error' 'no-error'}}>{{t "receive_package.invalid_quantity"}}</div>
+
+          <div class={{if isInvalidDescription 'show-error' 'no-error'}}>{{t "receive_package.invalid_description"}}</div>
+
+          <div class={{if isInvalidLocation 'show-error' 'no-error'}}>{{t "receive_package.invalid_location"}}</div>
+
+          {{#each package.errors.messages as |message|}}
+            <div class='show-error'>{{message}}</div>
+          {{/each}}
+
         </div>
-      {{/if}}
-      <div class="small-11 columns">
-
-        <div class={{if isInvalidInventoryNo 'show-error' 'no-error'}}>{{t "receive_package.invalid_inventory"}}</div>
-
-        <div class={{if isInvalidQuantity 'show-error' 'no-error'}}>{{t "receive_package.invalid_quantity"}}</div>
-
-        <div class={{if isInvalidDescription 'show-error' 'no-error'}}>{{t "receive_package.invalid_description"}}</div>
-
-        <div class={{if isInvalidLocation 'show-error' 'no-error'}}>{{t "receive_package.invalid_location"}}</div>
-
-        {{#each package.errors.messages as |message|}}
-          <div class='show-error'>{{message}}</div>
-        {{/each}}
-
       </div>
-    </div>
+    {{/if}}
 
     <div class="row box-white">
 

--- a/app/templates/receive_package.hbs
+++ b/app/templates/receive_package.hbs
@@ -4,13 +4,12 @@
 
     {{#if displayError}}
       <div class="row single-row form-errors">
-        {{#if isInvalidInventoryNo}}
+        {{#if isPackageInvalid}}
           <div class="small-1 columns">
             <i class="fa fa-exclamation-triangle"></i>
           </div>
         {{/if}}
         <div class="small-11 columns">
-
           <div class={{if isInvalidInventoryNo 'show-error' 'no-error'}}>{{t "receive_package.invalid_inventory"}}</div>
 
           <div class={{if isInvalidQuantity 'show-error' 'no-error'}}>{{t "receive_package.invalid_quantity"}}</div>
@@ -22,7 +21,6 @@
           {{#each package.errors.messages as |message|}}
             <div class='show-error'>{{message}}</div>
           {{/each}}
-
         </div>
       </div>
     {{/if}}

--- a/tests/acceptance/receive_package_test.js
+++ b/tests/acceptance/receive_package_test.js
@@ -1,47 +1,65 @@
-import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { module, test } from 'qunit';
-import '../factories/offer';
-import FactoryGuy from 'ember-data-factory-guy';
-import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
+import Ember from "ember";
+import startApp from "../helpers/start-app";
+import { module, test } from "qunit";
+import "../factories/offer";
+import FactoryGuy from "ember-data-factory-guy";
+import TestHelper from "ember-data-factory-guy/factory-guy-test-helper";
 
 var App, offer1, item1, package1, role;
 
-module('Receive package', {
+module("Receive package", {
   beforeEach: function() {
     App = startApp({}, 2);
     TestHelper.setup();
 
-    item1 = FactoryGuy.make("item", {state: "accepted"});
+    item1 = FactoryGuy.make("item", { state: "accepted" });
     offer1 = FactoryGuy.make("offer", { state: "received", items: [item1] });
-    package1 = FactoryGuy.make("package", { offerId: parseInt(offer1.id), state: "received", item: item1});
+    package1 = FactoryGuy.make("package", {
+      offerId: parseInt(offer1.id),
+      state: "received",
+      item: item1
+    });
 
     role = FactoryGuy.make("role");
 
-    $.mockjax({url: '/api/v1/role*', type: 'GET', status: 200,responseText: {
-      roles: [role.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/role*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        roles: [role.toJSON({ includeId: true })]
       }
     });
   },
   afterEach: function() {
-    Ember.run(function() { TestHelper.teardown(); });
-    Ember.run(App, 'destroy');
+    Ember.run(function() {
+      TestHelper.teardown();
+    });
+    Ember.run(App, "destroy");
   }
 });
 
 test("expecting, Location can't be blank when location not selected", function(assert) {
-  visit("/offers/"+offer1.id+"/receive_package/"+package1.id);
+  visit("/offers/" + offer1.id + "/receive_package/" + package1.id);
 
-  $.mockjax({url: '/api/v1/package*', type: 'GET', status: 200,responseText: {
-      packages: [package1.toJSON({includeId: true})]
+  $.mockjax({
+    url: "/api/v1/package*",
+    type: "GET",
+    status: 200,
+    responseText: {
+      packages: [package1.toJSON({ includeId: true })]
     }
   });
 
-  andThen(function(){
-    Ember.$('.confirmLink').click();
-    andThen(function(){
-      assert.equal($('.show-error').text().trim(), "Inventory number is invalid.Location can not be blank.");
+  andThen(function() {
+    Ember.$(".confirmLink").click();
+    andThen(function() {
+      assert.equal(
+        $(".show-error")
+          .text()
+          .trim(),
+        "Inventory number is invalid.Location can not be blank."
+      );
     });
   });
 });
-


### PR DESCRIPTION
Hi Team,
This PR has fix for resetting of receive package form on printing Inventory number. It was because all fields of Package were grouped inside single computed property (packageForm). On calling print_barcode, the inventory_number is updated which calls the packageForm computed property and it resets all fields. I separated inventory_number field from packageForm.
I refactored `getters` and `setters` of form element also refactored code related to validation.
Please review this PR.
Thanks.

