### PR TITLE
Fix: user search navigating to deleted page

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -51,7 +51,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     cancelSearch() {
       Ember.$("#searchText").blur();
       this.send("clearSearch");
-      this.transitionToRoute("my_list");
+      this.transitionToRoute("dashboard");
     }
   }
 });


### PR DESCRIPTION
The `my_list` page has been deleted and replaced by the dashboard. But this navigation was still trying to open the old page (causing an error popup)