### PR TITLE
GCW-2766-Dashboard Offers count remains same for both priority and non-priority.

### DIFF
--- a/app/helpers/offers-count-display.js
+++ b/app/helpers/offers-count-display.js
@@ -14,7 +14,10 @@ function applyCheckIconOrCountZero(isPriority) {
 
 export default Ember.Helper.helper(function(states) {
   const [statesObject, state, isSelfReviewer, isPriority] = states;
-  let searchState = isSelfReviewer ? `reviewer_${state}` : state;
+  let priorityOrNormalState = isPriority ? `priority_${state}` : state;
+  let searchState = isSelfReviewer
+    ? `reviewer_${priorityOrNormalState}`
+    : priorityOrNormalState;
   return (
     applyIcon(statesObject[searchState], isPriority) ||
     applyCheckIconOrCountZero(isPriority)


### PR DESCRIPTION
Hi Team,
This PR is fix for issue on dashboard for showing same count for both priority and non-priority states. Earlier logic ignores `priority_states` offers which in turn displays`non-priority` states offers. 
Please review this PR.