### PR TITLE
fix: new user and new company links not clickable on iphone

### DIFF
--- a/app/styles/templates/offer/_search_company.scss
+++ b/app/styles/templates/offer/_search_company.scss
@@ -4,6 +4,7 @@
   border-bottom: 0.1px solid;
   padding-bottom: 3%;
   padding-top: 3%;
+  cursor: pointer;
 
   a {
     text-decoration: underline;


### PR DESCRIPTION
Hi Team,

This PR fixes issue: `create new user` and `create new company` links are not clickable on the iPhone.

Please review.

Thanks.