### PR TITLE
fix add contact and add company links are not clickable on iphone

### DIFF
--- a/app/styles/templates/review_offer/_donor_details.scss
+++ b/app/styles/templates/review_offer/_donor_details.scss
@@ -24,6 +24,10 @@
     @media #{$small-only} {
       width: 10.5rem;
     }
+
+    .change-contact{
+      cursor: pointer;
+    }
   }
 
   .donor {


### PR DESCRIPTION
Hi Team,

This PR fixes add new contact and add new company links are not clickable on iphone.

Please review.

Thanks.