### PR TITLE
Gcw 2795 fix search bar ui issue on users page

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -31,7 +31,9 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
       let searchText = this.get("searchText");
       this.runTask(
         this.get("store")
-          .query("user", { searchText })
+          .query("user", {
+            searchText
+          })
           .then(users => {
             // Check the input has changed since the promise started
             if (searchText === this.get("searchText")) {
@@ -45,7 +47,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
   actions: {
     clearSearch() {
       this.set("searchText", "");
-      this.set("filteredResults", []);
+      this.set("results", []);
     },
 
     cancelSearch() {

--- a/app/styles/templates/_search.scss
+++ b/app/styles/templates/_search.scss
@@ -10,6 +10,10 @@
     margin: 0.5rem;
     border-radius: 0.25rem;
 
+    &::-ms-clear {
+      display: none;
+    }
+
     @media #{$small-only} {
       width: 97%;
     }


### PR DESCRIPTION
Hi team,

**Ticket link**
https://jira.crossroads.org.hk/browse/GCW-2795

**What does this PR do ?**
Bug:  This PR solves the issue of 
1. (If the close icon is selected, no further search results will appear if anything else is inputted into the search bar (until the page is refreshed)). 
2. Close icon glich on internet explorer 11 and edage.

**Impacted Areas**
Admin app users search widget.

Thanks