### PR TITLE
GCW-2831- Assigning assigned inventory number while receiving package receives package without inventory number

### DIFF
--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -225,7 +225,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     this.runTask(
       this.removeInventoryNumber()
         .then(() => {
-          pkg.set("inventoryNumber", null);
+          pkg.rollbackAttributes();
           pkg.save().then(() => this.redirectToReceiveOffer());
         })
         .catch(() => this.send("pkgUpdateError", pkg))

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -159,6 +159,13 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     return /^[A-Z]{0,1}[0-9]{5,6}(Q[0-9]*){0,1}$/i.test(value);
   },
 
+  resetInputs() {
+    this.set("packageForm.length", "");
+    this.set("packageForm.width", "");
+    this.set("packageForm.height", "");
+    this.set("isAllowedToPublish", false);
+  },
+
   isValidLabelRange({ startRange }) {
     const labelCount = Number(this.get("packageForm.labels"));
     return _.inRange(labelCount, startRange, 301);
@@ -226,7 +233,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
       this.removeInventoryNumber()
         .then(() => {
           pkg.rollbackAttributes();
-          pkg.save().then(() => this.redirectToReceiveOffer());
+          this.redirectToReceiveOffer();
         })
         .catch(() => this.send("pkgUpdateError", pkg))
     );
@@ -354,13 +361,6 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
             .join("\n")
         );
       }
-    },
-
-    resetInputs() {
-      this.set("invalidQuantity", false);
-      this.set("invalidInventoryNo", false);
-      this.set("invalidDescription", false);
-      this.set("hasErrors", false);
     }
   }
 });

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -164,7 +164,8 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
       "packageForm.length": "",
       "packageForm.width": "",
       "packageForm.height": "",
-      isAllowedToPublish: ""
+      // prettier-ignore
+      "isAllowedToPublish": ""
     });
   },
 

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -160,10 +160,12 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
   },
 
   resetInputs() {
-    this.set("packageForm.length", "");
-    this.set("packageForm.width", "");
-    this.set("packageForm.height", "");
-    this.set("isAllowedToPublish", false);
+    this.setProperties({
+      "packageForm.length": "",
+      "packageForm.width": "",
+      "packageForm.height": "",
+      isAllowedToPublish: ""
+    });
   },
 
   isValidLabelRange({ startRange }) {
@@ -227,7 +229,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
   },
 
   // ----- Ajax Request Methods -----
-  removeAndUnassignInventoryNumber() {
+  removeInventoryAndRollbackAttr() {
     let pkg = this.get("package");
     this.runTask(
       this.removeInventoryNumber()
@@ -315,7 +317,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
       if (this.get("isUnplannedPackage")) {
         this.cancelPackageOptions();
       } else {
-        this.removeAndUnassignInventoryNumber();
+        this.removeInventoryAndRollbackAttr();
       }
     },
 

--- a/app/routes/receive_package.js
+++ b/app/routes/receive_package.js
@@ -8,7 +8,7 @@ export default AuthorizeRoute.extend({
   setupController(controller, model) {
     this._super(controller, model);
     controller.set("package", model);
-    controller.send("resetInputs");
+    controller.resetInputs();
     controller.set("displayInventoryOptions", false);
     controller.set("autoGenerateInventory", true);
     controller.set("inputInventory", false);


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2831

### What does this PR do?

BUG: This PR rollback changes from `package` objects after receiving error from api. And removed `PUT` request on leaving the page.

### Impacted Areas

"Receive Package" page . On leaving the receive package page by pressing "Cancel" button will not receive package.