### PR TITLE
FIX=> iOS build failure for live

### DIFF
--- a/cordova/scripts/delete_arch.sh
+++ b/cordova/scripts/delete_arch.sh
@@ -1,3 +1,3 @@
-cd ./platforms/ios/S.\ Admin\ GoodCity/Plugins/cordova-plugin-twiliovoicesdk/TwilioVoice.framework
+cd ./platforms/ios/Admin\ GoodCity/Plugins/cordova-plugin-twiliovoicesdk/TwilioVoice.framework
 lipo -remove i386 TwilioVoice -o TwilioVoice
 lipo -remove x86_64 TwilioVoice -o TwilioVoice


### PR DESCRIPTION
This PR is for changing the path of plugins folder for removing incompatible architecture from `TwilioVoice.Framework` file. Destination changed from `S.Admin GoodCity` to `Admin GoodCity`.

Please review this PR.