### PR TITLE
Mark missing via endpoint + Quantity field change

### DIFF
--- a/app/components/receive-menu.js
+++ b/app/components/receive-menu.js
@@ -1,12 +1,14 @@
 import Ember from "ember";
 const { getOwner } = Ember;
 import AjaxPromise from "../utils/ajax-promise";
+import AsyncTasksMixin, { ERROR_STRATEGIES } from "../mixins/async_tasks";
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(AsyncTasksMixin, {
   hidden: true,
   packageId: null,
   store: Ember.inject.service(),
   messageBox: Ember.inject.service(),
+  packageService: Ember.inject.service(),
   displayUserPrompt: false,
 
   isReceived: Ember.computed.equal("package.state", "received"),
@@ -177,11 +179,11 @@ export default Ember.Component.extend({
 
     missing() {
       if (!this.get("isMissing")) {
-        this.updatePackage(p => {
-          p.set("state", "missing");
-          p.set("state_event", "mark_missing");
-          p.set("location", null);
-        });
+        const pkg = this.get("package");
+        this.runTask(
+          this.get("packageService").markMissing(pkg),
+          ERROR_STRATEGIES.MODAL
+        );
       }
     },
 

--- a/app/controllers/offer/search_label.js
+++ b/app/controllers/offer/search_label.js
@@ -52,7 +52,7 @@ export default searchLabelController.extend({
 
     return {
       notes: item.get("packageType.name"),
-      quantity: 1,
+      receivedQuantity: 1,
       packageTypeId,
       packageType: pkgType,
       offerId: item.get("offer.id"),

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -69,7 +69,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
 
   showPublishItemCheckBox: Ember.computed(
     "packageForm.quantity",
-    "package.quantity",
+    "package.receivedQuantity",
     function() {
       this.set("isAllowedToPublish", false);
       return +this.get("packageForm.quantity") === 1;
@@ -104,11 +104,11 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     get: function() {
       const pkg = this.get("package");
       return {
-        quantity: pkg.get("quantity"),
+        quantity: pkg.get("receivedQuantity"),
         length: pkg.get("length"),
         width: pkg.get("width"),
         height: pkg.get("height"),
-        labels: pkg.get("quantity")
+        labels: pkg.get("receivedQuantity")
       };
     }
   }),
@@ -204,7 +204,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     }
     pkg.set("state", "received");
     pkg.set("state_event", "mark_received");
-    pkg.set("quantity", pkgData.quantity);
+    pkg.set("receivedQuantity", pkgData.quantity);
     pkg.set("length", pkgData.length);
     pkg.set("width", pkgData.width);
     pkg.set("height", pkgData.height);

--- a/app/controllers/review_item/accept.js
+++ b/app/controllers/review_item/accept.js
@@ -23,7 +23,7 @@ export default Ember.Controller.extend({
 
   onItemPackagesChange: Ember.observer(
     "itemPackages.[]",
-    "itemPackages.@each.quantity",
+    "itemPackages.@each.receivedQuantity",
     "itemPackages.@each.length",
     "itemPackages.@each.width",
     "itemPackages.@each.height",
@@ -65,7 +65,7 @@ export default Ember.Controller.extend({
   returnPackageProperties(pkg) {
     return pkg.getProperties(
       "id",
-      "quantity",
+      "receivedQuantity",
       "length",
       "width",
       "height",
@@ -106,7 +106,7 @@ export default Ember.Controller.extend({
           obj.packageType = packageTypes[index] || packageTypes[0];
         }
         obj.hideComment = false;
-        obj.quantity = obj.quantity || 1;
+        obj.receivedQuantity = obj.receivedQuantity || 1;
         packages.pushObject(obj);
       });
     }
@@ -151,7 +151,7 @@ export default Ember.Controller.extend({
         hideComment: false,
         displayImageUrl: this.get("item.displayImageUrl"),
         notes: note_text,
-        quantity: 1,
+        receivedQuantity: 1,
         packageTypeId,
         packageType: this.get("store").peekRecord("packageType", packageTypeId),
         offerId: this.get("item.offer.id"),

--- a/app/mixins/async_tasks.js
+++ b/app/mixins/async_tasks.js
@@ -1,13 +1,48 @@
 import Ember from "ember";
+import _ from "lodash";
+
 const { getOwner } = Ember;
+
+const getString = (obj, path) => {
+  const val = _.get(obj, path);
+  return val && _.isString(val) ? val : null;
+};
+
+/**
+ * @enum {number}
+ * @readonly
+ * @memberof AsyncMixin
+ * @static
+ */
+export const ERROR_STRATEGIES = {
+  /** Will ignore errors */
+  IGNORE: 1,
+  /** Will display the error message in a modal */
+  MODAL: 2,
+  /** Will let the error go through */
+  RAISE: 3
+};
 
 export default Ember.Mixin.create({
   messageBox: Ember.inject.service(),
+
+  ERROR_STRATEGIES,
 
   // ---- Helpers
 
   __tasksCount: 0,
   __loadingView: null,
+  __modalActive: false,
+
+  __handleError(err, errorStrategy = ERROR_STRATEGIES.RAISE) {
+    if (errorStrategy === ERROR_STRATEGIES.RAISE) {
+      return Ember.RSVP.reject(err);
+    }
+
+    if (errorStrategy === ERROR_STRATEGIES.MODAL) {
+      return this.showErrorPopup(err);
+    }
+  },
 
   __incrementTaskCount(val = 1) {
     this.__tasksCount += val;
@@ -19,6 +54,23 @@ export default Ember.Mixin.create({
     }
   },
 
+  __toErrorMessage(reason) {
+    const defaultMessage = this.get("i18n").t("unexpected_error");
+
+    if (reason && reason.responseJSON) {
+      reason = reason.responseJSON;
+    }
+
+    return (
+      getString(reason, "error") ||
+      getString(reason, "message") ||
+      getString(reason, "errors[0].message") ||
+      getString(reason, "errors[0].detail.message") ||
+      getString(reason, "errors[0]") ||
+      defaultMessage
+    );
+  },
+
   __run(task) {
     const res = typeof task === "function" ? task() : task;
     return Ember.RSVP.resolve(res);
@@ -26,7 +78,15 @@ export default Ember.Mixin.create({
 
   // --- Mixin api
 
-  runTask(task) {
+  /**
+   * Runs the asynchronous task, showing and hiding loading spinners accordingly
+   *
+   * @memberof AsyncMixin
+   * @instance
+   * @param {Promise|Function} task the job to run
+   * @param {number} [errorStrategy] an indicator of how to handle the error
+   */
+  runTask(task, errorStrategy) {
     this.__incrementTaskCount();
     return this.__run(task)
       .then(res => {
@@ -35,7 +95,7 @@ export default Ember.Mixin.create({
       })
       .catch(err => {
         this.__incrementTaskCount(-1);
-        return Ember.RSVP.reject(err);
+        return this.__handleError(err, errorStrategy);
       });
   },
 
@@ -59,6 +119,19 @@ export default Ember.Mixin.create({
       this.__loadingView.destroy();
       this.__loadingView = null;
     }
+  },
+
+  showErrorPopup(reason) {
+    this.get("logger").error(reason);
+
+    if (this.get("__modalActive")) {
+      return;
+    }
+
+    this.set("__modalActive", true);
+    this.get("messageBox").alert(this.__toErrorMessage(reason), () => {
+      this.set("__modalActive", false);
+    });
   },
 
   i18nAlert(key, cb) {

--- a/app/services/package-service.js
+++ b/app/services/package-service.js
@@ -1,6 +1,19 @@
+import Ember from "ember";
 import ApiBaseService from "./api-base-service";
 
+const ID = record => {
+  switch (typeof record) {
+    case "string":
+    case "number":
+      return record;
+    default:
+      return record.get("id");
+  }
+};
+
 export default ApiBaseService.extend({
+  store: Ember.inject.service(),
+
   generateInventoryNumber() {
     return this.POST(`/inventory_numbers`);
   },
@@ -11,5 +24,14 @@ export default ApiBaseService.extend({
 
   removeInventoryNumber(code) {
     return this.PUT(`/inventory_numbers/remove_number`, code);
+  },
+
+  markMissing(pkg) {
+    const id = ID(pkg);
+
+    return this.PUT(`/packages/${id}/mark_missing`).then(data => {
+      this.get("store").pushPayload(data);
+      return this.get("store").peekRecord("package", id);
+    });
   }
 });

--- a/app/templates/components/receive-item.hbs
+++ b/app/templates/components/receive-item.hbs
@@ -72,7 +72,7 @@
         <div class="ellipsis name one-line-ellipsis" style="display: inline !important;">
           {{package.receivedQuantity}} x {{package.packageName}}
         </div>
-        <span style="margin-left: 0.25rem;">{{package.remainingQty}}/{{package.totalDesignatedQty}}/{{package.totalDispatchedQty}}</span>
+        <span style="margin-left: 0.25rem;">{{package.availableQuantity}}/{{package.designatedQuantity}}/{{package.dispatchedQuantity}}</span>
       {{/toggle-receive-menu-list}}
       {{receive-menu packageId=package.id}}
       {{#toggle-receive-menu-list}}

--- a/app/templates/review_item/accept.hbs
+++ b/app/templates/review_item/accept.hbs
@@ -40,7 +40,7 @@
                 </div>
                 <div class="row bottom">
                   <div class="small-6 columns ui inner">
-                    {{numeric-input id=(concat 'qty' index) name="qty" value=pkg.quantity placeholder=(t "placeholder.qty") maxlength="8" required='true' pattern="\d{1,8}"}}
+                    {{numeric-input id=(concat 'qty' index) name="qty" value=pkg.receivedQuantity placeholder=(t "placeholder.qty") maxlength="8" required='true' pattern="\d{1,8}"}}
                   </div>
                   <div class="small-2 columns ui inner">
                     {{numeric-input name="length" id=(concat 'length' index) value=pkg.length placeholder=(t "placeholder.length") maxlength="8" pattern="\d{1,8}"}}

--- a/tests/acceptance/accept-test.js
+++ b/tests/acceptance/accept-test.js
@@ -133,11 +133,11 @@ test("visit accepted item with item_type", function(assert) {
     // display quantity value
     assert.equal(
       parseInt($(".detail_container:eq(0) input[name='qty']").val()),
-      package1.get("quantity")
+      package1.get("receivedQuantity")
     );
     assert.equal(
       parseInt($(".detail_container:eq(1) input[name='qty']").val()),
-      package2.get("quantity")
+      package2.get("receivedQuantity")
     );
 
     // display length value

--- a/tests/acceptance/receive_package_test.js
+++ b/tests/acceptance/receive_package_test.js
@@ -141,7 +141,7 @@ test("If location not selected Receive button is disabled", function(assert) {
 
 test("If quantity is zero or below Receive button is disabled and it gives validation error", function(assert) {
   Ember.run(function() {
-    package1.set("quantity", 0);
+    package1.set("receivedQuantity", 0);
   });
   visit("/offers/" + offer1.id + "/receive_package/" + package1.id);
   andThen(function() {

--- a/tests/factories/package.js
+++ b/tests/factories/package.js
@@ -11,7 +11,7 @@ FactoryGuy.define("package", {
   },
   default: {
     id: FactoryGuy.generate("id"),
-    quantity: 1,
+    receivedQuantity: 1,
     labels: 1,
     length: 10,
     width: 10,

--- a/tests/unit/models/package-test.js
+++ b/tests/unit/models/package-test.js
@@ -1,34 +1,43 @@
-import { test, moduleForModel } from 'ember-qunit';
-import Ember from 'ember';
+import { test, moduleForModel } from "ember-qunit";
+import Ember from "ember";
 
-moduleForModel('package', 'Package Model', {
-  needs: ['model:item', 'model:package_type', 'model:designation', 'model:location', 'model:donor_condition', 'model:orders_package', 'model:package_image', 'model:packages_location']
+moduleForModel("package", "Package Model", {
+  needs: [
+    "model:item",
+    "model:package_type",
+    "model:designation",
+    "model:location",
+    "model:donor_condition",
+    "model:orders_package",
+    "model:package_image",
+    "model:packages_location"
+  ]
 });
 
-test('check attributes', function(assert){
+test("check attributes", function(assert) {
   assert.expect(18);
   var model = this.subject();
-  var state_event = Object.keys(model.toJSON()).indexOf('state_event') > -1;
-  var state = Object.keys(model.toJSON()).indexOf('state') > -1;
-  var receivedQuantity = Object.keys(model.toJSON()).indexOf('receivedQuantity') > -1;
-  var favouriteImageId = Object.keys(model.toJSON()).indexOf('favouriteImageId') > -1;
-  var designationId = Object.keys(model.toJSON()).indexOf('designationId') > -1;
-  var sentOn = Object.keys(model.toJSON()).indexOf('sentOn') > -1;
-  var grade = Object.keys(model.toJSON()).indexOf('grade') > -1;
-  var inventoryNumber = Object.keys(model.toJSON()).indexOf('inventoryNumber') > -1;
-  var offerId = Object.keys(model.toJSON()).indexOf('offerId') > -1;
-  var updatedAt = Object.keys(model.toJSON()).indexOf('updatedAt') > -1;
-  var createdAt = Object.keys(model.toJSON()).indexOf('createdAt') > -1;
-  var rejectedAt = Object.keys(model.toJSON()).indexOf('rejectedAt') > -1;
-  var receivedAt = Object.keys(model.toJSON()).indexOf('receivedAt') > -1;
-  var notes = Object.keys(model.toJSON()).indexOf('notes') > -1;
-  var height = Object.keys(model.toJSON()).indexOf('height') > -1;
-  var width = Object.keys(model.toJSON()).indexOf('width') > -1;
-  var length = Object.keys(model.toJSON()).indexOf('length') > -1;
-  var quantity = Object.keys(model.toJSON()).indexOf('quantity') > -1;
+  var state_event = Object.keys(model.toJSON()).indexOf("state_event") > -1;
+  var state = Object.keys(model.toJSON()).indexOf("state") > -1;
+  var receivedQuantity =
+    Object.keys(model.toJSON()).indexOf("receivedQuantity") > -1;
+  var favouriteImageId =
+    Object.keys(model.toJSON()).indexOf("favouriteImageId") > -1;
+  var designationId = Object.keys(model.toJSON()).indexOf("designationId") > -1;
+  var sentOn = Object.keys(model.toJSON()).indexOf("sentOn") > -1;
+  var grade = Object.keys(model.toJSON()).indexOf("grade") > -1;
+  var inventoryNumber =
+    Object.keys(model.toJSON()).indexOf("inventoryNumber") > -1;
+  var offerId = Object.keys(model.toJSON()).indexOf("offerId") > -1;
+  var updatedAt = Object.keys(model.toJSON()).indexOf("updatedAt") > -1;
+  var createdAt = Object.keys(model.toJSON()).indexOf("createdAt") > -1;
+  var rejectedAt = Object.keys(model.toJSON()).indexOf("rejectedAt") > -1;
+  var receivedAt = Object.keys(model.toJSON()).indexOf("receivedAt") > -1;
+  var notes = Object.keys(model.toJSON()).indexOf("notes") > -1;
+  var height = Object.keys(model.toJSON()).indexOf("height") > -1;
+  var width = Object.keys(model.toJSON()).indexOf("width") > -1;
+  var length = Object.keys(model.toJSON()).indexOf("length") > -1;
 
-
-  assert.ok(quantity);
   assert.ok(length);
   assert.ok(width);
   assert.ok(height);
@@ -48,36 +57,51 @@ test('check attributes', function(assert){
   assert.ok(state_event);
 });
 
-test('Relationships with other models', function(assert){
+test("Relationships with other models", function(assert) {
   assert.expect(14);
 
-  var pkg = this.store().modelFor('package');
-  var relationshipsWithItem = Ember.get(pkg, 'relationshipsByName').get('item');
-  var relationshipsWithPackageType = Ember.get(pkg, 'relationshipsByName').get('packageType');
-  var relationshipsWithDesignation = Ember.get(pkg, 'relationshipsByName').get('designation');
-  var relationshipsWithLocation = Ember.get(pkg, 'relationshipsByName').get('location');
-  var relationshipsWithDonorCondition = Ember.get(pkg, 'relationshipsByName').get('donorCondition');
-  var relationshipsWithOrdersPackages = Ember.get(pkg, 'relationshipsByName').get('ordersPackages');
-  var relationshipsWithPackagesLocation = Ember.get(pkg, 'relationshipsByName').get('packagesLocations');
+  var pkg = this.store().modelFor("package");
+  var relationshipsWithItem = Ember.get(pkg, "relationshipsByName").get("item");
+  var relationshipsWithPackageType = Ember.get(pkg, "relationshipsByName").get(
+    "packageType"
+  );
+  var relationshipsWithDesignation = Ember.get(pkg, "relationshipsByName").get(
+    "designation"
+  );
+  var relationshipsWithLocation = Ember.get(pkg, "relationshipsByName").get(
+    "location"
+  );
+  var relationshipsWithDonorCondition = Ember.get(
+    pkg,
+    "relationshipsByName"
+  ).get("donorCondition");
+  var relationshipsWithOrdersPackages = Ember.get(
+    pkg,
+    "relationshipsByName"
+  ).get("ordersPackages");
+  var relationshipsWithPackagesLocation = Ember.get(
+    pkg,
+    "relationshipsByName"
+  ).get("packagesLocations");
 
-  assert.equal(relationshipsWithPackagesLocation.key, 'packagesLocations');
-  assert.equal(relationshipsWithPackagesLocation.kind, 'hasMany');
+  assert.equal(relationshipsWithPackagesLocation.key, "packagesLocations");
+  assert.equal(relationshipsWithPackagesLocation.kind, "hasMany");
 
-  assert.equal(relationshipsWithOrdersPackages.key, 'ordersPackages');
-  assert.equal(relationshipsWithOrdersPackages.kind, 'hasMany');
+  assert.equal(relationshipsWithOrdersPackages.key, "ordersPackages");
+  assert.equal(relationshipsWithOrdersPackages.kind, "hasMany");
 
-  assert.equal(relationshipsWithDonorCondition.key, 'donorCondition');
-  assert.equal(relationshipsWithDonorCondition.kind, 'belongsTo');
+  assert.equal(relationshipsWithDonorCondition.key, "donorCondition");
+  assert.equal(relationshipsWithDonorCondition.kind, "belongsTo");
 
-  assert.equal(relationshipsWithLocation.key, 'location');
-  assert.equal(relationshipsWithLocation.kind, 'belongsTo');
+  assert.equal(relationshipsWithLocation.key, "location");
+  assert.equal(relationshipsWithLocation.kind, "belongsTo");
 
-  assert.equal(relationshipsWithDesignation.key, 'designation');
-  assert.equal(relationshipsWithDesignation.kind, 'belongsTo');
+  assert.equal(relationshipsWithDesignation.key, "designation");
+  assert.equal(relationshipsWithDesignation.kind, "belongsTo");
 
-  assert.equal(relationshipsWithPackageType.key, 'packageType');
-  assert.equal(relationshipsWithPackageType.kind, 'belongsTo');
+  assert.equal(relationshipsWithPackageType.key, "packageType");
+  assert.equal(relationshipsWithPackageType.kind, "belongsTo");
 
-  assert.equal(relationshipsWithItem.key, 'item');
-  assert.equal(relationshipsWithItem.kind, 'belongsTo');
+  assert.equal(relationshipsWithItem.key, "item");
+  assert.equal(relationshipsWithItem.kind, "belongsTo");
 });

--- a/tests/unit/models/package-test.js
+++ b/tests/unit/models/package-test.js
@@ -15,7 +15,7 @@ moduleForModel("package", "Package Model", {
 });
 
 test("check attributes", function(assert) {
-  assert.expect(18);
+  assert.expect(17);
   var model = this.subject();
   var state_event = Object.keys(model.toJSON()).indexOf("state_event") > -1;
   var state = Object.keys(model.toJSON()).indexOf("state") > -1;


### PR DESCRIPTION
This PR is dependant on https://github.com/crossroads/api.goodcity/pull/926

## Changes

- The admin app now **only** reads/writes the `received_quantity` field, which will be used by the API to **inventorize** the package (when location and inventory_number are set)
- Marking a package as missing is now done via the `/package/1/mark_missing` endpoint, which will **uninventorize** the package

Roadmap: We will eventually want the `inventory` action to be through its own entry point. But for now, to ensure backwards compatibility, we'll let that happen in the default `PUT update`