### PR TITLE
FIX=> iOS app not working on iOS 13.1+ version

### DIFF
--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -85,7 +85,7 @@
   <access launch-external="yes" origin="tel:*" />
   <access origin="*" />
   <allow-intent href="https://maps.google.com/*" />
-  <engine name="ios" spec="https://github.com/apache/cordova-ios.git#5.0.0" />
+  <engine name="ios" spec="~5.0.0" />
   <engine name="android" spec="8.0.0" />
   <engine name="windows" spec="~4.3.1" />
   <plugin name="cordova-plugin-statusbar" spec="~2.1.1" />


### PR DESCRIPTION
Hi Team,
This PR fixes iOS app not working on 13.1+ version. As issue posted by Tim that app is not working on iPad 7th generation device.
I tested it on emulator with the upgraded version its working in fine.
Please review this PR.