### PR TITLE
Inventory image editor fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,8 @@ jobs:
           name: Wait for Ember test server to start
           command: dockerize -wait tcp://localhost:4201 -timeout 1m
       - run:
-          name: Sleep for a while
-          command: sleep 30
-      - run:
           name: Run Ember tests
-          command: COVERAGE=true yarn test:ci
+          command: yarn test:ci
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           command: dockerize -wait tcp://localhost:4201 -timeout 1m
       - run:
           name: Run Ember tests
-          command: COVERAGE=true yarn test:ci
+          command: yarn test:ci
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           command: dockerize -wait tcp://localhost:4201 -timeout 1m
       - run:
           name: Run Ember tests
-          command: yarn test:ci
+          command: COVERAGE=true yarn test:ci
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
           name: Wait for Ember test server to start
           command: dockerize -wait tcp://localhost:4201 -timeout 1m
       - run:
+          name: Sleep for a while
+          command: sleep 30
+      - run:
           name: Run Ember tests
           command: COVERAGE=true yarn test:ci
       - persist_to_workspace:

--- a/app/controllers/image_editor.js
+++ b/app/controllers/image_editor.js
@@ -7,7 +7,7 @@ import utils from "../utils/utility-methods";
 /**
  * Image Editor
  *
- * This is based on the old `edit_images` controller (shared.goodcity)
+ * This is a modified version of the old `edit_images` controller (shared.goodcity)
  * This version supports any time of imageable record. In our case Item and Package
  *
  */
@@ -315,7 +315,7 @@ export default Ember.Controller.extend(AsyncMixin, {
 
       this.runTask(() => {
         return this.get("imageService").createImage(record, identifier, {
-          favourite
+          favourite: favourite
         });
       }, this.ERROR_STRATEGIES.MODAL);
     },

--- a/app/controllers/image_editor.js
+++ b/app/controllers/image_editor.js
@@ -1,0 +1,345 @@
+import Ember from "ember";
+import { translationMacro as t } from "ember-i18n";
+import config from "../config/environment";
+import AsyncMixin from "../mixins/async_tasks";
+import utils from "../utils/utility-methods";
+
+/**
+ * Image Editor
+ *
+ * This is based on the old `edit_images` controller (shared.goodcity)
+ * This version supports any time of imageable record. In our case Item and Package
+ *
+ */
+export default Ember.Controller.extend(AsyncMixin, {
+  session: Ember.inject.service(),
+  store: Ember.inject.service(),
+  messageBox: Ember.inject.service(),
+  i18n: Ember.inject.service(),
+  cordova: Ember.inject.service(),
+  imageService: Ember.inject.service(),
+  previewImage: null,
+  addPhotoLabel: t("edit_images.add_photo"),
+  isReady: false,
+  isExpanded: false,
+  backBtnVisible: true,
+  loadingPercentage: t("edit_images.image_uploading"),
+  uploadedFileDate: null,
+
+  record: Ember.computed.alias("model"),
+
+  initActionSheet(onSuccess) {
+    return window.plugins.actionsheet.show(
+      {
+        buttonLabels: [
+          this.locale("edit_images.upload").string,
+          this.locale("edit_images.camera").string,
+          this.locale("edit_images.cancel").string
+        ]
+      },
+      function(buttonIndex) {
+        if (buttonIndex === 1) {
+          navigator.camera.getPicture(onSuccess, null, {
+            quality: 40,
+            destinationType: navigator.camera.DestinationType.DATA_URL,
+            sourceType: navigator.camera.PictureSourceType.PHOTOLIBRARY
+          });
+        }
+        if (buttonIndex === 2) {
+          navigator.camera.getPicture(onSuccess, null, {
+            correctOrientation: true,
+            quality: 40,
+            destinationType: navigator.camera.DestinationType.DATA_URL,
+            sourceType: navigator.camera.PictureSourceType.CAMERA
+          });
+        }
+        if (buttonIndex === 3) {
+          window.plugins.actionsheet.hide();
+        }
+      }
+    );
+  },
+
+  previewMatchesFavourite: Ember.computed(
+    "previewImage",
+    "favouriteImage",
+    function() {
+      return this.get("previewImage") === this.get("favouriteImage");
+    }
+  ),
+
+  noImage: Ember.computed.empty("images"),
+
+  images: Ember.computed("record.images.length", function() {
+    //The reason for sorting is because by default it's ordered by favourite
+    //then id order. If another image is made favourite then deleted the first image
+    //by id order is made favourite which can be second image in list which seems random.
+
+    //Sort by id ascending except place new images id = 0 at end
+    return (this.getWithDefault("record.images", []) || Ember.A())
+      .toArray()
+      .sort(function(a, b) {
+        a = parseInt(a.get("id"), 10);
+        b = parseInt(b.get("id"), 10);
+        if (a === 0) {
+          return 1;
+        }
+        if (b === 0) {
+          return -1;
+        }
+        return a - b;
+      });
+  }),
+
+  supportsFavouriteImage: Ember.computed("record", function() {
+    const record = this.get("record");
+
+    return utils.supportsField(record, "favouriteImageId");
+  }),
+
+  favouriteImage: Ember.computed(
+    "images.@each.favourite",
+    "supportsFavouriteImage",
+    "record.favouriteImageId",
+    function() {
+      return this.get("supportsFavouriteImage")
+        ? this.get("record.favouriteImage")
+        : this.get("images").findBy("favourite");
+    }
+  ),
+
+  initPreviewImage: Ember.on(
+    "init",
+    Ember.observer("record", "images.[]", function() {
+      var image = this.get("images.firstObject");
+      if (image) {
+        this.send("setPreview", image);
+      }
+    })
+  ),
+
+  //css related
+  previewImageBgCss: Ember.computed(
+    "previewImage",
+    "isExpanded",
+    "previewImage.angle",
+    {
+      get() {
+        var css = this.get("instructionBoxCss");
+        if (!this.get("previewImage")) {
+          return css;
+        }
+
+        var imgTag = new Image();
+        imgTag.onload = () => {
+          var newCSS = new Ember.Handlebars.SafeString(
+            css +
+              "background-image:url(" +
+              this.get("previewImage.imageUrl") +
+              ");" +
+              "background-size: " +
+              (this.get("isExpanded") ? "contain" : "cover") +
+              ";"
+          );
+          this.set("previewImageBgCss", newCSS);
+        };
+
+        imgTag.src = this.get("previewImage.imageUrl");
+
+        return new Ember.Handlebars.SafeString(
+          css +
+            "background-image:url('assets/images/image_loading.gif');" +
+            "background-size: 'inherit';"
+        );
+      },
+
+      set(key, value) {
+        return value;
+      }
+    }
+  ),
+
+  instructionBoxCss: Ember.computed("previewImage", "isExpanded", function() {
+    var height = Ember.$(window).height() * 0.6;
+    return new Ember.Handlebars.SafeString("min-height:" + height + "px;");
+  }),
+
+  thumbImageCss: Ember.computed(function() {
+    var imgWidth = Math.min(120, Ember.$(window).width() / 4 - 14);
+    return new Ember.Handlebars.SafeString(
+      "width:" + imgWidth + "px; height:" + imgWidth + "px;"
+    );
+  }),
+
+  locale(str) {
+    return this.get("i18n").t(str);
+  },
+
+  confirmRemoveImage() {
+    const deferred = Ember.RSVP.defer();
+
+    this.get("messageBox").custom(
+      this.locale("edit_images.delete_confirm"),
+      this.locale("edit_images.cancel_item"),
+      () => deferred.resolve(false),
+      this.locale("edit_images.remove_image"),
+      () => deferred.resolve(true)
+    );
+
+    return deferred.promise;
+  },
+
+  actions: {
+    done() {
+      window.history.back();
+    },
+
+    setPreview(image) {
+      this.get("images").setEach("selected", false);
+      image.set("selected", true);
+      this.set("previewImage", image);
+    },
+
+    setFavourite() {
+      const record = this.get("record");
+      const img = this.get("previewImage");
+
+      if (this.get("supportsFavouriteImage")) {
+        record.set("favouriteImageId", img.get("id"));
+        record.save().catch(error => {
+          record.rollbackAttributes();
+          throw error;
+        });
+      } else {
+        this.get("images").setEach("favourite", false);
+        this.get("previewImage").set("favourite", true);
+        this.get("previewImage")
+          .save()
+          .catch(error => {
+            this.get("images").forEach(i => i.rollbackAttributes());
+            throw error;
+          });
+      }
+    },
+
+    deleteImage(img) {
+      this.confirmRemoveImage().then(allowed => {
+        if (!allowed) return;
+
+        this.runTask(() => {
+          img.deleteRecord();
+          return img.save().then(i => {
+            i.unloadRecord();
+            this.initPreviewImage();
+            if (!this.get("favouriteImage")) {
+              this.send("setFavourite");
+            }
+          });
+        }, this.ERROR_STRATEGIES.MODAL);
+      });
+    },
+
+    expandImage() {
+      this.toggleProperty("isExpanded");
+    },
+
+    //file upload
+    triggerUpload() {
+      // For Cordova application
+      if (config.cordova.enabled) {
+        var onSuccess = (function(_this) {
+          return function(path) {
+            console.log(path);
+            var dataURL = "data:image/jpg;base64," + path;
+
+            $("input[type='file']").fileupload(
+              "option",
+              "formData"
+            ).file = dataURL;
+            $("input[type='file']").fileupload("add", { files: [dataURL] });
+          };
+        })(this);
+
+        this.initActionSheet(onSuccess);
+      } else {
+        // Trigger the file selection
+        Ember.$("#photo-list input[type='file']").trigger("click");
+      }
+    },
+
+    uploadReady() {
+      this.set("isReady", true);
+    },
+
+    uploadStart(e, data) {
+      this.set("uploadedFileDate", data);
+      Ember.$(".loading-image-indicator").show();
+    },
+
+    cancelUpload() {
+      if (this.get("uploadedFileDate")) {
+        this.get("uploadedFileDate").abort();
+      }
+    },
+
+    uploadProgress(e, data) {
+      e.target.disabled = true; // disable image-selection
+      var progress = parseInt((data.loaded / data.total) * 100, 10) || 0;
+      this.set("addPhotoLabel", progress + "%");
+      this.set(
+        "loadingPercentage",
+        this.get("i18n").t("edit_images.image_uploading") + progress + "%"
+      );
+    },
+
+    uploadComplete(e) {
+      e.target.disabled = false; // enable image-selection
+      this.set("uploadedFileDate", null);
+      Ember.$(".loading-image-indicator.hide_image_loading").hide();
+      this.set("addPhotoLabel", this.get("i18n").t("edit_images.add_photo"));
+      this.set(
+        "loadingPercentage",
+        this.get("i18n").t("edit_images.image_uploading")
+      );
+    },
+
+    uploadSuccess(e, data) {
+      const identifier =
+        data.result.version +
+        "/" +
+        data.result.public_id +
+        "." +
+        data.result.format;
+      const record = this.get("record");
+      const favourite = this.get("images.length") === 0;
+
+      this.runTask(() => {
+        return this.get("imageService").createImage(record, identifier, {
+          favourite
+        });
+      }, this.ERROR_STRATEGIES.MODAL);
+    },
+
+    rotateImageRight() {
+      var angle = this.get("previewImage.angle");
+      angle = (angle + 90) % 360;
+      this.send("rotateImage", angle);
+    },
+
+    rotateImageLeft() {
+      var angle = this.get("previewImage.angle");
+      angle = (angle ? angle - 90 : 270) % 360;
+      this.send("rotateImage", angle);
+    },
+
+    rotateImage(angle) {
+      var image = this.get("previewImage");
+      image.set("angle", angle);
+      Ember.run.debounce(this, this.saveImageRotation, image, 400);
+    }
+  },
+
+  saveImageRotation(image) {
+    image.save();
+  }
+});

--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -336,9 +336,7 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
 
     assignImageToPackage() {
       const itemId = this.get("package.item.id");
-      this.transitionToRoute("item.edit_images", itemId, {
-        queryParams: { isUnplannedPackage: true }
-      });
+      this.transitionToRoute("package.image_editor", this.get("package"));
     },
 
     moveBack() {

--- a/app/mixins/async_tasks.js
+++ b/app/mixins/async_tasks.js
@@ -25,6 +25,7 @@ export const ERROR_STRATEGIES = {
 
 export default Ember.Mixin.create({
   messageBox: Ember.inject.service(),
+  logger: Ember.inject.service(),
 
   ERROR_STRATEGIES,
 

--- a/app/models/package.js
+++ b/app/models/package.js
@@ -74,15 +74,9 @@ export default DS.Model.extend({
     return !res ? "" : res + "cm";
   }),
 
-  displayImageUrl: Ember.computed(
-    "favouriteImage",
-    "item.displayImageUrl",
-    function() {
-      return this.get("favouriteImage")
-        ? this.get("favouriteImage.thumbImageUrl")
-        : this.get("item.displayImageUrl");
-    }
-  ),
+  displayImageUrl: Ember.computed("favouriteImage", function() {
+    return this.getWithDefault("favouriteImage.thumbImageUrl", "");
+  }),
 
   images: hasMany("image", {
     async: false
@@ -90,17 +84,10 @@ export default DS.Model.extend({
 
   packageImages: Ember.computed.alias("images"),
 
-  favouriteImage: Ember.computed("packageImages.@each.favourite", function() {
-    return (
-      this.get("packageImages")
-        .filterBy("favourite")
-        .get("firstObject") ||
-      this.get("packageImages")
-        .sortBy("id")
-        .get("firstObject") ||
-      this.get("item.displayImage") ||
-      null
-    );
+  favouriteImage: Ember.computed("images.@each.favourite", function() {
+    const images = this.get("images");
+
+    return images.findBy("favourite") || images.sortBy("id").get("firstObject");
   }),
 
   hasOneDesignatedPackage: Ember.computed(

--- a/app/router.js
+++ b/app/router.js
@@ -41,7 +41,15 @@ Router.map(function() {
       "item",
       { resetNamespace: true, path: "/items/:item_id" },
       function() {
-        this.route("edit_images");
+        this.route("image_editor");
+      }
+    );
+
+    this.route(
+      "package",
+      { resetNamespace: true, path: "/package/:package_id" },
+      function() {
+        this.route("image_editor");
       }
     );
 

--- a/app/router.js
+++ b/app/router.js
@@ -41,7 +41,7 @@ Router.map(function() {
       "item",
       { resetNamespace: true, path: "/items/:item_id" },
       function() {
-        this.route("image_editor");
+        this.route("edit_images");
       }
     );
 

--- a/app/routes/package/image_editor.js
+++ b/app/routes/package/image_editor.js
@@ -1,0 +1,9 @@
+import AuthorizeRoute from "../authorize";
+
+export default AuthorizeRoute.extend({
+  controllerName: "image_editor",
+
+  renderTemplate() {
+    this.render("image_editor");
+  }
+});

--- a/app/services/api-base-service.js
+++ b/app/services/api-base-service.js
@@ -41,10 +41,9 @@ export default Ember.Service.extend({
     const { authorizedRequest = true } = opts;
     return this._request(
       urlWithParams(url, opts),
-      {
-        ...opts,
+      _.extend({}, opts, {
         action: "GET"
-      },
+      }),
       authorizedRequest
     );
   },
@@ -53,11 +52,10 @@ export default Ember.Service.extend({
     const { authorizedRequest = true } = opts;
     return this._request(
       url,
-      {
-        ...opts,
+      _.extend({}, opts, {
         action: "POST",
         body
-      },
+      }),
       authorizedRequest
     );
   },
@@ -66,11 +64,10 @@ export default Ember.Service.extend({
     const { authorizedRequest = true } = opts;
     return this._request(
       url,
-      {
-        ...opts,
+      _.extend({}, opts, {
         action: "PUT",
         body
-      },
+      }),
       authorizedRequest
     );
   },
@@ -79,10 +76,9 @@ export default Ember.Service.extend({
     const { authorizedRequest = true } = opts;
     return this._request(
       url,
-      {
-        ...opts,
+      _.extend({}, opts, {
         action: "DELETE"
-      },
+      }),
       authorizedRequest
     );
   }

--- a/app/services/api-base-service.js
+++ b/app/services/api-base-service.js
@@ -13,17 +13,23 @@ function urlWithParams(url, params) {
 
 export default Ember.Service.extend({
   // ----- Services -----
+  store: Ember.inject.service(),
   session: Ember.inject.service(),
 
   // ----- Utilities -----
   _request(url, options, authorizedRequest) {
-    const { action, body } = options;
+    const { action, body, persist = false } = options;
     return new AjaxPromise(
       url,
       action,
       authorizedRequest ? this.get("session.authToken") : null,
       body
-    );
+    ).then(data => {
+      if (persist) {
+        this.get("store").pushPayload(data);
+      }
+      return data;
+    });
   },
 
   // ----- CRUD ACTIONS -----
@@ -36,6 +42,7 @@ export default Ember.Service.extend({
     return this._request(
       urlWithParams(url, opts),
       {
+        ...opts,
         action: "GET"
       },
       authorizedRequest
@@ -47,6 +54,7 @@ export default Ember.Service.extend({
     return this._request(
       url,
       {
+        ...opts,
         action: "POST",
         body
       },
@@ -59,6 +67,7 @@ export default Ember.Service.extend({
     return this._request(
       url,
       {
+        ...opts,
         action: "PUT",
         body
       },
@@ -71,6 +80,7 @@ export default Ember.Service.extend({
     return this._request(
       url,
       {
+        ...opts,
         action: "DELETE"
       },
       authorizedRequest

--- a/app/services/image-service.js
+++ b/app/services/image-service.js
@@ -1,20 +1,7 @@
-import Ember from "ember";
 import ApiBaseService from "./api-base-service";
 import _ from "lodash";
 
-const ID = record => {
-  switch (typeof record) {
-    case "string":
-    case "number":
-      return record;
-    default:
-      return record.get("id");
-  }
-};
-
 export default ApiBaseService.extend({
-  store: Ember.inject.service(),
-
   createImage(imageableRecord, cloudinaryId, params = {}) {
     const modelName = imageableRecord.get("constructor.modelName");
 

--- a/app/services/image-service.js
+++ b/app/services/image-service.js
@@ -1,0 +1,41 @@
+import Ember from "ember";
+import ApiBaseService from "./api-base-service";
+import _ from "lodash";
+
+const ID = record => {
+  switch (typeof record) {
+    case "string":
+    case "number":
+      return record;
+    default:
+      return record.get("id");
+  }
+};
+
+export default ApiBaseService.extend({
+  store: Ember.inject.service(),
+
+  createImage(imageableRecord, cloudinaryId, params = {}) {
+    const modelName = imageableRecord.get("constructor.modelName");
+
+    return this.POST(
+      `/images`,
+      {
+        image: {
+          imageable_type: _.upperFirst(_.camelCase(modelName)),
+          imageable_id: imageableRecord.get("id"),
+          cloudinary_id: cloudinaryId,
+          favourite: _.get(params, "favourite", false)
+        }
+      },
+      { persist: true }
+    ).then(data => {
+      const id = Number(data["image"]["id"]);
+      const img = this.get("store").peekRecord("image", id);
+
+      imageableRecord.getWithDefault("images", []).pushObject(img);
+
+      return img;
+    });
+  }
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -32,6 +32,7 @@
 @import "templates/review_offer/donor_details";
 @import "templates/review_item/reject";
 @import "templates/review_item";
+@import "templates/image_editor";
 @import "templates/delivery/contact_details";
 @import "templates/delivery/drop_off";
 @import "node_modules/ember-searchable-select/app/styles/ember-searchable-select/style";

--- a/app/styles/templates/_image_editor.scss
+++ b/app/styles/templates/_image_editor.scss
@@ -1,0 +1,97 @@
+.image-editor-page {
+  padding: 0;
+
+  #photo-list {
+    margin-left: 0;
+    li {
+      list-style-type: none;
+      padding: 3px;
+      display: inline-block;
+      vertical-align: middle;
+      position: relative;
+      img:hover, .selected img {
+        border-color: white;
+      }
+    }
+    .disabled {
+      border-color: $org-grey !important;
+      color: $org-grey !important;
+    }
+    .fa-star {
+      position: absolute;
+      top: -3px;
+      right: -3px;
+    }
+    .noImage {
+      left: 20%;
+      a {
+        text-decoration: underline;
+        font-weight: bold;
+        color: #596573 !important;
+      }
+    }
+  }
+
+  #add-photo {
+    font-size: 0.8em;
+    vertical-align: middle;
+    color: white;
+    border: white 2px dashed;
+    border-radius: 2px;
+    background-color: $white-with-shadow;
+    text-align: center;
+    padding: 5px;
+  }
+
+  #main-image {
+    margin-bottom: 20px;
+    background-color: black;
+    > div {
+      height: 92%;
+      width: 100%;
+      background-repeat: no-repeat;
+      background-position: center center;
+      position: relative;
+    }
+  }
+
+  #main-image-controls {
+    color: white;
+    background-color: $black-with-shadow;
+    bottom: 0;
+    left: 0;
+    font-size: 34px;
+    padding: 0.5rem 0.5rem;
+    display: inline-block;
+    height: 8% !important;
+
+    .fa-star-o, .fa-star, .fa-trash, .fa-repeat, .fa-undo {
+      float: right;
+    }
+    .fa-expand, .fa-compress {
+      float: left;
+    }
+    .fa-star-o, .fa-star, .fa-trash, .fa-repeat, {
+      margin-left: 1rem;
+    }
+  }
+
+  #main-image.is-expanded {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 10;
+    margin-bottom: 0;
+    padding-bottom: 3%;
+  }
+
+  .hidden_file_input{
+    opacity: 0;
+    height: 0;
+    z-index: -100;
+    width: 0;
+    position: absolute;
+  }
+}

--- a/app/templates/image_editor.hbs
+++ b/app/templates/image_editor.hbs
@@ -1,0 +1,67 @@
+<section class="main-section row image-editor-page">
+
+  <div id="main-image" class="{{if isExpanded 'is-expanded'}}">
+    {{#unless noImage}}
+      <div style={{previewImageBgCss}}>
+      </div>
+
+      <div id="main-image-controls">
+        <a {{action "deleteImage" previewImage}} title={{t "edit_images.delete_tooltip"}}>
+          <i class="fa fa-trash"></i>
+        </a>
+        <a {{action "setFavourite"}} title={{t "edit_images.favourite_tooltip"}}>
+          <i class="fa {{if previewMatchesFavourite 'fa-star' 'fa-star-o'}}"></i>
+        </a>
+        <a {{action "rotateImageRight"}} >
+          <i class="fa fa-repeat"></i>
+        </a>
+        <a {{action "rotateImageLeft"}} >
+          <i class="fa fa-undo"></i>
+        </a>
+        <a {{action "expandImage"}} title={{t "edit_images.fullscreen_tooltip"}}>
+          <i class="fa {{if isExpanded 'fa-compress' 'fa-expand'}}"></i>
+        </a>
+      </div>
+
+    {{else}}
+    <div class="center-box" style={{instructionBoxCss}}>
+      <span class="center-item">
+        <h3>{{t "edit_images.donating_what"}}</h3>
+        <p>{{t "edit_images.take_photos"}}</p>
+      </span>
+    </div>
+    {{/unless}}
+  </div>
+
+  <ul id="photo-list" class="{{if isExpanded 'hidden'}}">
+    <li>
+      <a id="add-photo" {{action "triggerUpload"}} class="center-box {{unless isReady 'disabled'}}" style={{thumbImageCss}}>
+        <span class="center-item">
+          <i class="fa fa-camera"></i>
+          {{addPhotoLabel}}
+        </span>
+      </a>
+      {{cloudinary-upload ready="uploadReady" progress="uploadProgress"
+        always="uploadComplete" done="uploadSuccess" submit="uploadProgress"
+        offerId=offer.id}}
+    </li>
+    {{#unless noImage}}
+      {{#each images as |image|}}
+        <li>
+          <a {{action "setPreview" image}} class="{{if image.selected 'selected'}}">
+            <img src="{{image.thumbImageUrl}}" style={{thumbImageCss}} class="thumb" />
+            <i class="fa fa-star {{if (js-x 'p0 == p1' image.id favouriteImage.id) '' 'hidden'}}"></i>
+          </a>
+        </li>
+      {{/each}}
+    {{/unless}}
+  </ul>
+</section>
+
+<div class="btm {{if isExpanded 'hidden'}}">
+  <div class="row">
+    <div class="small-12 columns">
+      <button {{ action "done"}} class="button expand">{{t "done"}}</button>
+    </div>
+  </div>
+</div>

--- a/app/templates/receive_package.hbs
+++ b/app/templates/receive_package.hbs
@@ -41,8 +41,8 @@
 
       <div class="small-3 columns">
         <span class="image-box" {{action 'assignImageToPackage'}}>
-          {{#if package.item.displayImageUrl}}
-          <img src={{package.item.displayImageUrl}} class="thumb" />
+          {{#if package.displayImageUrl}}
+          <img src={{package.displayImageUrl}} class="thumb" />
           {{else}}
           <i class="fa fa-camera"></i><br />
           {{t 'items.add_item.add_images'}}

--- a/app/utils/utility-methods.js
+++ b/app/utils/utility-methods.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 export default {
   arrayExists(arr) {
     return arr && arr.length;
@@ -9,5 +11,10 @@ export default {
 
   stringifyArray(arr) {
     return Array.isArray(arr) ? arr.toString() : "";
+  },
+
+  supportsField(record, field) {
+    const fields = record.get("constructor.attributes");
+    return fields.has(_.camelCase(field));
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12305,7 +12305,7 @@ sha@~2.0.1:
 
 "shared-goodcity@git://github.com/crossroads/shared.goodcity.git#master":
   version "0.0.0"
-  resolved "git://github.com/crossroads/shared.goodcity.git#d0a58d679189761f9968281ad777a44d30e9cc69"
+  resolved "git://github.com/crossroads/shared.goodcity.git#629f28a97126237e4e33df13d22f41612657a923"
   dependencies:
     cryptiles "^4.1.2"
     ember-cli-babel "^5.1.6"


### PR DESCRIPTION
**Original issue:**

The `edit_images` page from the "Inventory form" would modify the Item, and not the Package.
After looking into it, I found this `edit_images` page not to be generic at all. References to the item are hardcoded everywhere. Sadly, since it is shared with the donor app, refactoring it is very risky.

**Fix:**

I copied this page into admin, as `image_editor` and transformed it to be completely generic. It can accept any kind of Imageable record, and will simply allow us to update its images.

**Note 1**

The way pages are shared between donor and admin app is _dangerous_. It's messy, un-reusable and we need to move away from this. I'm in support any actions you take toward this goal :)
If anyone has trouble understanding why, feel free to ping me with questions.

**Note2**

This is the first part of the refactoring, only applies to Package. But I will be replacing the image page on Item as well in an upcoming PR. Trying to get this on live sooner than later to help with all the bugs the team is seeing

