### PR TITLE
GCW-3250-Google Play apps must target API 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
   android_build_and_deploy:
     <<: *defaults
     docker:
-      - image: circleci/android:api-26-node8-alpha
+      - image: circleci/android:api-29-node
     environment:
       JVM_OPTS: -Xmx3200m
       KEYSTORE: goodcity.keystore

--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -86,7 +86,7 @@
   <access origin="*" />
   <allow-intent href="https://maps.google.com/*" />
   <engine name="ios" spec="~5.0.0" />
-  <engine name="android" spec="8.0.0" />
+  <engine name="android" spec="9.0.0" />
   <engine name="windows" spec="~4.3.1" />
   <plugin name="cordova-plugin-statusbar" spec="~2.1.1" />
   <plugin name="cordova-plugin-device" spec="^1.1.1" />


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3250

### What does this PR do?

This PR upgrades android to api level 29.