### PR TITLE
GCW-3303-Deprecate usage of APP_VERSION in Admin app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ workflows:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-3303-Deprecate-Usage-of-AppVersion)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ workflows:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live|GCW-3303-Deprecate-Usage-of-AppVersion)$/
+                only: /^(master|live)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
             master)
               ENVIRONMENT=staging
               ;;
-            preview)
+            master)
               ENVIRONMENT=preview
               ;;
             live)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,6 @@ jobs:
             master)
               ENVIRONMENT=staging
               ;;
-            GCW-3303-Deprecate-Usage-of-AppVersion)
-            ENVIRONMENT=staging
-              ;;
             preview)
               ENVIRONMENT=preview
               ;;
@@ -432,13 +429,13 @@ workflows:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live|GCW-3303-Deprecate-Usage-of-AppVersion)$/
+                only: /^(master|live)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build
             filters:
               branches:
-                only: /^(master|live|GCW-3303-Deprecate-Usage-of-AppVersion)$/
+                only: /^(master|live)$/
         - ios_build_and_deploy:
             requires:
               - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,13 +429,13 @@ workflows:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-3303-Deprecate-Usage-of-AppVersion)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-3303-Deprecate-Usage-of-AppVersion)$/
         - ios_build_and_deploy:
             requires:
               - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,10 @@ jobs:
             master)
               ENVIRONMENT=staging
               ;;
-            master)
+            GCW-3303-Deprecate-Usage-of-AppVersion)
+            ENVIRONMENT=staging
+              ;;
+            preview)
               ENVIRONMENT=preview
               ;;
             live)

--- a/Rakefile
+++ b/Rakefile
@@ -230,13 +230,12 @@ def app_id
 end
 
 def app_version
-  if ENV["CI"]
-    is_staging ? "#{ENV['APP_VERSION']}.#{ENV['CIRCLE_BUILD_NUM']||ENV['BUILD_BUILDNUMBER']}" : ENV['APP_VERSION']
-  elsif @ver
-    @ver
+  package_json = File.open(File.join(File.expand_path('../',  __FILE__), 'package.json'), 'r').read
+  version_number = JSON.parse(package_json)['version']
+  if is_staging
+    "#{version_number}.#{ENV['CIRCLE_BUILD_NUM']||ENV['BUILD_BUILDNUMBER']}"
   else
-    print "Enter GoodCity app version: "
-    @ver = STDIN.gets.strip
+    version_number
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require 'json'
+
 default_platform :ios
 
 class FastlaneCore::Shell
@@ -43,8 +45,9 @@ platform :ios do
 
   desc "Upload to TestFlight"
   lane :production do
-    raise_if_no_env_var(["APP_VERSION", "PILOT_USERNAME", "PILOT_IPA", "PILOT_TESTER_EMAIL", "ITUNESCONNECT_PASSWORD"])
-    version_number = ENV["APP_VERSION"]
+    raise_if_no_env_var(["PILOT_USERNAME", "PILOT_IPA", "PILOT_TESTER_EMAIL", "ITUNESCONNECT_PASSWORD"])
+    package_json = File.open(File.join(File.expand_path('../../',  __FILE__), 'package.json'), 'r').read
+    version_number = JSON.parse(package_json)['version']
     xsh %{ source ~/.circlerc; bundle exec fastlane fastlane-credentials add --username $PILOT_USERNAME --password $ITUNESCONNECT_PASSWORD }
     latest_testflight_build_number(version: version_number, username: ENV['PILOT_USERNAME'])
     pilot


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3304

### What does this PR do?

FEATURE: Deprecates use of `APP_VERSION` environment variable in the app builds. Delegates to `package.json` instead.

NOTE: Previously, bumping the app version required updating `package.json` and updating `APP_VERSION` in CircleCI. This was was unnecessary duplication and made the builds less automated. After this PR is merged, version will be set entirely from code in the projects `package.json` file and we can delete `APP_VERSION` from CircleCI


### Impacted Areas

- iOS App Store app version
- Google Play app version