### PR TITLE
GCW-3466 Remove the hand pointer

### DIFF
--- a/app/styles/templates/components/_canned-messages-overlay.scss
+++ b/app/styles/templates/components/_canned-messages-overlay.scss
@@ -75,6 +75,10 @@
     flex: 0.5;
   }
 
+  .content-preview {
+    cursor: default;
+  }
+
   .language-container {
     display: flex;
     flex: 0.5;
@@ -110,4 +114,3 @@
     white-space: initial;
   }
 }
-

--- a/app/templates/components/canned-content.hbs
+++ b/app/templates/components/canned-content.hbs
@@ -1,5 +1,5 @@
 
-  <div {{action 'handleClick'}}>
+  <div class='content-preview' {{action 'handleClick'}}>
     <div>
       {{#if cannedMessage.name}}
         {{cannedMessage.name}}


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3466

### What does this PR do?
Removes the hovering over the pre-set messages to add in a message, the hand icon is used for the cursor for the part that isn't selected.