### PR TITLE
GCW-3487-Offer_id missing in params for item notification

### DIFF
--- a/app/controllers/my_notifications.js
+++ b/app/controllers/my_notifications.js
@@ -235,6 +235,9 @@ export default Ember.Controller.extend({
         const messageId = notification.get("id");
         var message = this.store.peekRecord("message", messageId);
         var route = this.get("messagesUtil").getRoute(message);
+        if (message.get("messageableType") === "Item") {
+          route[1] = message.get("item.offer.id");
+        }
         this.transitionToRoute.apply(this, route);
       }
     },


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3487

### What does this PR do?

BUG: ADMIN iOS: Error when clicking on item notification in notification tab in admin app fix