### PR TITLE
FIX: Shared chat displays are broken when there is no donor

### DIFF
--- a/app/controllers/message_base_controller.js
+++ b/app/controllers/message_base_controller.js
@@ -59,14 +59,13 @@ export default Ember.Controller.extend({
         this.get("recipientId") ||
         (this.get("isPrivate") ? null : this.get("offer.createdById"));
 
-      if (recipientId) {
-        messages = messages.filter(m => {
-          return (
-            m.get("recipientId") === recipientId ||
-            m.get("senderId") === recipientId
-          );
-        });
-      }
+      messages = messages.filter(m => {
+        return (
+          recipientId &&
+          (m.get("recipientId") === recipientId ||
+            m.get("senderId") === recipientId)
+        );
+      });
 
       return messages.filter(m => {
         return Boolean(m.get("isPrivate")) === this.get("isPrivate");

--- a/app/controllers/my_notifications.js
+++ b/app/controllers/my_notifications.js
@@ -183,8 +183,9 @@ export default Ember.Controller.extend({
     const donorId = message.get("offer.createdById");
 
     return (
-      message.get("senderId") !== donorId &&
-      message.get("recipientId") !== donorId
+      !donorId ||
+      (message.get("senderId") !== donorId &&
+        message.get("recipientId") !== donorId)
     );
   },
 

--- a/app/controllers/review_offer/share/index.js
+++ b/app/controllers/review_offer/share/index.js
@@ -23,7 +23,6 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     "allMessages.length",
     "allMessages.@each.{senderId,recipientId}",
     function() {
-      const donorId = this.get("offer.createdById");
       return this.get("allMessages")
         .filterBy("offerId", this.get("offer.id"))
         .filter(m =>

--- a/app/models/message.js
+++ b/app/models/message.js
@@ -69,6 +69,10 @@ export default DS.Model.extend({
 
       const donorId = this.get("offer.createdById");
 
+      if (!donorId) {
+        return !this.get("isPrivate");
+      }
+
       // It's a chat with an external user (a charity) if:
       //  - It's public
       //  - It does not involve the donor

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "EMBER_CLI_CORDOVA=0 ENVIRONMENT=development ember serve --port 4201 --live-reload-port 35730",
+    "start:staging": "EMBER_CLI_CORDOVA=0 ENVIRONMENT=staging ember serve --port 4201 --live-reload-port 35730",
     "test": "EMBER_CLI_CORDOVA=0 ENVIRONMENT=test ember test --server --test-port 7358",
     "test:ci": "EMBER_CLI_CORDOVA=0 ENVIRONMENT=test ember-pretty-test",
     "build:web:development": "EMBER_CLI_CORDOVA=0 ENVIRONMENT=development ember build",
@@ -64,7 +65,7 @@
     "ember-cli-inject-live-reload": "^1.7.0",
     "ember-cli-qunit": "^2.2.4",
     "ember-cli-release": "^1.0.0-beta.2",
-    "ember-cli-sass": "^7.1.2",
+    "ember-cli-sass": "^5.6.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^2.1.0",
     "ember-data": "~2.11.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ember-cli-inject-live-reload": "^1.7.0",
     "ember-cli-qunit": "^2.2.4",
     "ember-cli-release": "^1.0.0-beta.2",
-    "ember-cli-sass": "^5.6.0",
+    "ember-cli-sass": "^7.1.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^2.1.0",
     "ember-data": "~2.11.0",


### PR DESCRIPTION
Issue:

The admin app knows that messages are from charities when `user != donor`, that however breaks when there is no donor at all (if an admin created the offer).
