### PR TITLE
GCW-2167-Review item problem, item gets saved without clicking 'save only'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,6 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -208,9 +207,6 @@ GEM
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     netrc (0.11.0)
-    nokogiri (1.11.2)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
     nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
     os (1.1.1)
@@ -270,8 +266,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
-  ruby
-  x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   capistrano (= 3.16.0)
@@ -282,4 +277,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/app/controllers/review_item.js
+++ b/app/controllers/review_item.js
@@ -10,6 +10,7 @@ export default Ember.Controller.extend({
   defaultPackage: Ember.computed.alias("model.packageType"),
   item: Ember.computed.alias("model"),
   cordova: Ember.inject.service(),
+  isPackageTypeChanged: false,
 
   isItemVanished: Ember.computed.or("item.isDeleted", "item.isDeleting"),
 
@@ -96,17 +97,6 @@ export default Ember.Controller.extend({
   actions: {
     setEditing(value) {
       this.set("isEditing", value);
-    },
-
-    returnToItemDetails() {
-      const existingPkgType = this.get("existingPackageType");
-      if (
-        !existingPkgType ||
-        existingPkgType.id !== this.get("model.packageType").id
-      ) {
-        this.set("model.packageType", existingPkgType);
-      }
-      this.transitionToRoute("review_offer", this.get("item.offer"));
     },
 
     selectPackageType() {

--- a/app/controllers/review_item/accept.js
+++ b/app/controllers/review_item/accept.js
@@ -233,6 +233,7 @@ export default Ember.Controller.extend({
         return item.save().finally(() => {
           this.set("itemSaving", false);
           loadingView.destroy();
+          this.set("reviewItem.isPackageTypeChanged", true);
           this.transitionToRoute("review_offer.items");
           this.get("reviewOfferController").set(
             "displayCompleteReviewPopup",

--- a/app/routes/review_item/accept.js
+++ b/app/routes/review_item/accept.js
@@ -5,5 +5,17 @@ export default AuthorizeRoute.extend({
     this._super(controller, model);
     controller.notifyPropertyChange("itemTypeId");
     controller.set("packageTypeUpdated", null);
+  },
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      const reviewItem = controller.get("reviewItem");
+      if (!reviewItem.get("isPackageTypeChanged")) {
+        reviewItem.set(
+          "model.packageType",
+          reviewItem.get("existingPackageType")
+        );
+      }
+    }
   }
 });

--- a/app/templates/review_item.hbs
+++ b/app/templates/review_item.hbs
@@ -1,6 +1,6 @@
 <nav class="tab-bar item_details_title">
   <section class="left-small">
-    <div class="back" id="backToItem" {{action "returnToItemDetails"}}>{{t "back"}}</div>
+    {{#link-to 'review_offer' item.offer classNames="back"}}{{t "back"}}{{/link-to}}
   </section>
   <section class="middle tab-bar-section">
     <h1 class="title">{{t "review_item.title"}}</h1>

--- a/tests/acceptance/review-item-test.js
+++ b/tests/acceptance/review-item-test.js
@@ -133,7 +133,7 @@ test("Back button redirects to review offer page", function(assert) {
 
   visit(`/offers/${offerId}/review_item/${itemId}`);
   andThen(function() {
-    click("#backToItem");
+    click(".back");
   });
   andThen(function() {
     assert.equal(currentURL(), `/offers/${offerId}/review_offer/items`);


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2167

### What does this PR do?

This issue was fixed for the `back` button but it did not handle the browser back scenario. This PR fixes all possible scenarios of leaving the `accept` page by resetting the Controller.