### PR TITLE
Disable chats with no recipients

### DIFF
--- a/app/locales/en/translations.coffee
+++ b/app/locales/en/translations.coffee
@@ -41,6 +41,9 @@ I18nTranslationsEn =
       "description": "Donors will not be able to book a delivery or drop-off on the 'holiday' dates listed below."
       "delete_confirm": "Are you sure you wish to delete this holiday?"
 
+    "chats":
+      "no_recipient": "Missing recipient. This chat is disabled"
+
     "offer":
       "title": "Offer"
       "donor": "Details"

--- a/app/locales/zh-tw/translations.coffee
+++ b/app/locales/zh-tw/translations.coffee
@@ -41,6 +41,9 @@ I18nTranslationsZhTw =
       "description": "捐贈者將無法於「假期」內預約送貨！"
       "delete_confirm": "你確定要刪除此項假期嗎？"
 
+    "chats":
+      "no_recipient": "Missing recipient. This chat is disabled"
+
     "offer":
       "title": "捐贈細節"
       "donor": "Details"

--- a/app/templates/message_template.hbs
+++ b/app/templates/message_template.hbs
@@ -1,4 +1,7 @@
 <section class="message-section">
+  {{#if missingRecipient}}
+    <div class="warning-text">{{t 'chats.no_recipient' }}</div>
+  {{/if}}
   <div class="row">
     <div class="small-12 columns">
       {{#href-to-link-to}}
@@ -53,7 +56,7 @@
           </div>
         </div>
       {{/if}}
-      <div class="row message-base">
+      <div class={{concat "row message-base " (if disabled 'disabled')}}>
         <div class="small-12 columns">
           {{#validatable-form class="form-horizontal" action="sendMessage" on="submit"}}
             <div class="row ui">

--- a/yarn.lock
+++ b/yarn.lock
@@ -13185,7 +13185,7 @@ sha@~2.0.1:
 
 "shared-goodcity@git://github.com/crossroads/shared.goodcity.git#master":
   version "0.0.0"
-  resolved "git://github.com/crossroads/shared.goodcity.git#8405e7b8ae7fef73f4866aee7e5900153d571dfe"
+  resolved "git://github.com/crossroads/shared.goodcity.git#e7d5e23d429f526ca0a1afb412b08eea71bce7fb"
   dependencies:
     cryptiles "^4.1.2"
     ember-cli-babel "^5.1.6"


### PR DESCRIPTION
If a chat has no recipient (donor or charity), it is disabled to prevent staff members from sending messages to nobody (which causes side effects later down the line)