### PR TITLE
FIX: Clear inventory number state

### DIFF
--- a/app/controllers/receive_package.js
+++ b/app/controllers/receive_package.js
@@ -23,7 +23,6 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
   isAndroidDevice: false,
   displayError: false,
   // ----- Aliases -----
-  inventoryNumber: Ember.computed.alias("package.inventoryNumber"),
   package: Ember.computed.alias("model"),
 
   item: Ember.computed.alias("model.item"),
@@ -264,8 +263,8 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
     });
   },
 
-  generateInventoryNumber() {
-    this.runTask(
+  async generateInventoryNumber() {
+    await this.runTask(
       this.get("packageService")
         .generateInventoryNumber()
         .then(data => this.set("inventoryNumber", data.inventory_number))
@@ -391,7 +390,10 @@ export default Ember.Controller.extend(AsyncTasksMixin, {
               )
             );
           })
-          .catch(() => this.send("pkgUpdateError", pkg))
+          .catch(() => {
+            pkg.rollbackAttributes();
+            this.send("pkgUpdateError", pkg);
+          })
       );
     },
 

--- a/app/routes/receive_package.js
+++ b/app/routes/receive_package.js
@@ -33,14 +33,16 @@ export default AuthorizeRoute.extend({
     controller.set("displayInventoryOptions", false);
     controller.set("autoGenerateInventory", true);
     controller.set("inputInventory", false);
-    model.get("inventoryNumber");
+
     this.setupPrinterId(controller);
 
     if (model.get("isReceived") && model.get("inventoryNumber")) {
       return controller.redirectToReceiveOffer();
     }
     if (!model.get("inventoryNumber")) {
-      controller.generateInventoryNumber();
+      await controller.generateInventoryNumber();
+    } else {
+      controller.set("inventoryNumber", model.get("inventoryNumber"));
     }
 
     const valueHkDollar = await this.get("packageService").getItemValuation({


### PR DESCRIPTION
Issue:

Due to the following line:

```javascript
  inventoryNumber: Ember.computed.alias("package.inventoryNumber"),
```

The package's inventory number is set on the package object itself when initialized.

When the user _leaves_ the `/receive_package/:id` page without clicking "cancel" (e.g browser back button), this field isn't cleared and stays on the package locally. It later gets persisted when another page triggers `pkg.save()`

FIX:

- We only set the inventory number on the package during the PUT request to save the package. If the user exits the page beforehand, nothing gets set on the package object

